### PR TITLE
wget from the HTTPS endpoint of repo.continuum.io

### DIFF
--- a/anaconda/Dockerfile
+++ b/anaconda/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Travis Swicegood
 
 RUN apt-get update && apt-get install -y wget bzip2
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet http://repo.continuum.io/archive/Anaconda-2.2.0-Linux-x86_64.sh && \
+    wget --quiet https://repo.continuum.io/archive/Anaconda-2.2.0-Linux-x86_64.sh && \
     /bin/bash /Anaconda-2.2.0-Linux-x86_64.sh -b -p /opt/conda && \
     rm /Anaconda-2.2.0-Linux-x86_64.sh && \
     /opt/conda/bin/conda install --yes conda==3.10.1

--- a/anaconda3/Dockerfile
+++ b/anaconda3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Travis Swicegood
 
 RUN apt-get update && apt-get install -y wget bzip2
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet http://repo.continuum.io/archive/Anaconda3-2.2.0-Linux-x86_64.sh && \
+    wget --quiet https://repo.continuum.io/archive/Anaconda3-2.2.0-Linux-x86_64.sh && \
     /bin/bash /Anaconda3-2.2.0-Linux-x86_64.sh -b -p /opt/conda && \
     rm /Anaconda3-2.2.0-Linux-x86_64.sh && \
     /opt/conda/bin/conda install --yes conda==3.10.1

--- a/miniconda/Dockerfile
+++ b/miniconda/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Travis Swicegood
 
 RUN apt-get update && apt-get install -y wget bzip2
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet http://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86_64.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86_64.sh && \
     /bin/bash /Miniconda-3.9.1-Linux-x86_64.sh -b -p /opt/conda && \
     rm Miniconda-3.9.1-Linux-x86_64.sh && \
     /opt/conda/bin/conda install --yes conda==3.10.1

--- a/miniconda3/Dockerfile
+++ b/miniconda3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Travis Swicegood
 
 RUN apt-get update && apt-get install -y wget bzip2
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet http://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh && \
     /bin/bash /Miniconda3-3.9.1-Linux-x86_64.sh -b -p /opt/conda && \
     rm Miniconda3-3.9.1-Linux-x86_64.sh && \
     /opt/conda/bin/conda install --yes conda==3.10.1


### PR DESCRIPTION
Now that repo.continuum.io has an HTTPS endpoint (should be the default), switch to using it. Fixes #3.