### PR TITLE
Make sure `libgthread-2.0.so.0` is present

### DIFF
--- a/anaconda/Dockerfile
+++ b/anaconda/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:7.4
 
 MAINTAINER Travis Swicegood
 
-RUN apt-get update && apt-get install -y wget bzip2 ca-certificates
+RUN apt-get update && apt-get install -y wget bzip2 ca-certificates libglib2.0-0
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/archive/Anaconda-2.2.0-Linux-x86_64.sh && \
     /bin/bash /Anaconda-2.2.0-Linux-x86_64.sh -b -p /opt/conda && \

--- a/anaconda3/Dockerfile
+++ b/anaconda3/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:7.4
 
 MAINTAINER Travis Swicegood
 
-RUN apt-get update && apt-get install -y wget bzip2 ca-certificates
+RUN apt-get update && apt-get install -y wget bzip2 ca-certificates libglib2.0-0
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/archive/Anaconda3-2.2.0-Linux-x86_64.sh && \
     /bin/bash /Anaconda3-2.2.0-Linux-x86_64.sh -b -p /opt/conda && \

--- a/miniconda/Dockerfile
+++ b/miniconda/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:7.4
 
 MAINTAINER Travis Swicegood
 
-RUN apt-get update && apt-get install -y wget bzip2 ca-certificates
+RUN apt-get update && apt-get install -y wget bzip2 ca-certificates libglib2.0-0
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86_64.sh && \
     /bin/bash /Miniconda-3.9.1-Linux-x86_64.sh -b -p /opt/conda && \

--- a/miniconda3/Dockerfile
+++ b/miniconda3/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:7.4
 
 MAINTAINER Travis Swicegood
 
-RUN apt-get update && apt-get install -y wget bzip2 ca-certificates
+RUN apt-get update && apt-get install -y wget bzip2 ca-certificates libglib2.0-0
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh && \
     /bin/bash /Miniconda3-3.9.1-Linux-x86_64.sh -b -p /opt/conda && \


### PR DESCRIPTION
Fixes ContinuumIO/docker-images#8.

Loading PyQt runs into issues currently due to this missing dependency.