### PR TITLE
Add VCS

### DIFF
--- a/anaconda/Dockerfile
+++ b/anaconda/Dockerfile
@@ -3,7 +3,8 @@ FROM debian:7.4
 MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
-    libglib2.0-0 libxext6 libsm6 libxrender1
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/archive/Anaconda2-2.4.0-Linux-x86_64.sh && \
     /bin/bash /Anaconda2-2.4.0-Linux-x86_64.sh -b -p /opt/conda && \

--- a/anaconda3/Dockerfile
+++ b/anaconda3/Dockerfile
@@ -3,7 +3,8 @@ FROM debian:7.4
 MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
-    libglib2.0-0 libxext6 libsm6 libxrender1
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/archive/Anaconda3-2.4.0-Linux-x86_64.sh && \
     /bin/bash /Anaconda3-2.4.0-Linux-x86_64.sh -b -p /opt/conda && \

--- a/miniconda/Dockerfile
+++ b/miniconda/Dockerfile
@@ -3,7 +3,8 @@ FROM debian:7.4
 MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
-    libglib2.0-0 libxext6 libsm6 libxrender1
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh && \
     /bin/bash /Miniconda-3.16.0-Linux-x86_64.sh -b -p /opt/conda && \

--- a/miniconda3/Dockerfile
+++ b/miniconda3/Dockerfile
@@ -3,7 +3,8 @@ FROM debian:7.4
 MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
-    libglib2.0-0 libxext6 libsm6 libxrender1
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh && \
     /bin/bash /Miniconda3-3.16.0-Linux-x86_64.sh -b -p /opt/conda && \


### PR DESCRIPTION
Many conda packages are built by cloning a repo. This provides the necessary executables to clone the relevant repo types.