### PR TITLE
conda_builder_linux: optionally silence output, create output folders

### DIFF
--- a/conda_builder_linux/CHANGELOG
+++ b/conda_builder_linux/CHANGELOG
@@ -1,0 +1,8 @@
+5.11-5.2-0-1: 2016-03-31:
+	- add /opt/miniconda/conda-bld/linux64 and /opt/miniconda/conda-bld/linux-32 folders for mount points for build output
+	- Made output upon login with internal_startup.sh only show up when no build command is passed
+	- enabled sudo when tty is not available
+
+5.11-5.2-0-0: 2016-03-30: First release
+	- naming scheme is Centos version-GCC version-base image revision-builder image revision
+	- base image refers to https://github.com/ContinuumIO/docker-images/tree/master/centos5_gcc5_base

--- a/conda_builder_linux/Dockerfile
+++ b/conda_builder_linux/Dockerfile
@@ -20,6 +20,8 @@ RUN ln -sf /usr/local/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
 
 RUN useradd -m --uid 1000 -G wheel dev
 RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+# do not require tty for sudo access
+RUN echo 'Defaults:dev   !requiretty' >> /etc/sudoers
 
 # this is where we'll mount shares from the user
 RUN mkdir -p /opt/share

--- a/conda_builder_linux/Dockerfile
+++ b/conda_builder_linux/Dockerfile
@@ -27,6 +27,8 @@ RUN echo 'Defaults:dev   !requiretty' >> /etc/sudoers
 RUN mkdir -p /opt/share
 ADD build/internal_startup.sh /opt/share/internal_startup.sh
 ADD build/alias_32bit.sh /opt/share/alias_32bit.sh
+RUN mkdir -p /opt/miniconda/conda-bld/work/linux-64
+RUN mkdir -p /opt/miniconda/conda-bld/work/linux-32
 RUN chmod -R 777 /opt
 
 WORKDIR /home/dev

--- a/conda_builder_linux/build/alias_32bit.sh
+++ b/conda_builder_linux/build/alias_32bit.sh
@@ -1,0 +1,1 @@
+/bin/uname_x64 $@ | sed s/x86_64/i686/g

--- a/conda_builder_linux/build/internal_startup.sh
+++ b/conda_builder_linux/build/internal_startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "${ABI}" ]]; then
-    echo "WARNING: No ABI default set.  Falling back to compatibility mode with GCC 4."
+    ABI_WARNING="WARNING: No ABI default set.  Falling back to compatibility mode with GCC 4."
     export ABI=4
 fi
 
@@ -39,28 +39,6 @@ else
     sudo chmod +x /bin/uname
 fi
 
-echo
-echo "Welcome to the conda-builder image, brought to you by Continuum Analytics."
-echo
-echo "Binaries produced with this image should be compatible with any Linux OS"
-echo "that is at least CentOS 5 or newer (Glibc lower bound), and anything "
-echo "that uses G++ 5.2 or older (libstdc++ upper bound)"
-echo
-echo "    GCC is: $(gcc --version | head -1)"
-echo "    Default C++ ABI: ${ABI} (C++$([ "${ABI}" == "4" ] && echo "98" || echo "11"))"
-echo "    GLIBC is: $(getconf GNU_LIBC_VERSION)"
-echo "    ld/binutils is: $(ld --version | head -1)"
-echo
-echo "    Native arch is x86_64.  ${ARCH_DOC}"
-echo
-echo "    The dev user (currently signed in) has passwordless sudo access."
-echo "    miniconda (2.7) is installed at /opt/miniconda."
-echo "    git is also available."
-
-if [ -f "/home/dev/.gitconfig" ]; then
-    echo "    Your .gitconfig has been imported."
-fi
-
 # jumping through hoops for file ownership - we can't have the owner be
 #    the native linux owner, and we also can't have permissions too wide open,
 #    or ssh complains.
@@ -72,20 +50,46 @@ if [ -f /id_rsa ]; then
     sudo chmod 600 .ssh/id_rsa
     echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
     echo -e "Host bremen\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-    echo "    Your ssh private key has been imported for passwordless ssh."
 fi
-
-echo
-
-echo "Helpful aliases:"
-echo "    clone_recipes: clones the conda/conda-recipes repo from Github"
-echo "    clone_anaconda: clones the continuumIO/anaconda (private) repo from Github"
-echo "    anaconda_setup: clones anaconda repo and sets up continuum internal build system."
-
-echo
 
 if [[ $# < 1 ]]; then
     # interactive session
+    echo "$ABI_WARNING"
+    echo
+    echo "Welcome to the conda-builder image, brought to you by Continuum Analytics."
+    echo
+    echo "Binaries produced with this image should be compatible with any Linux OS"
+    echo "that is at least CentOS 5 or newer (Glibc lower bound), and anything "
+    echo "that uses G++ 5.2 or older (libstdc++ upper bound)"
+    echo
+    echo "    GCC is: $(gcc --version | head -1)"
+    echo "    Default C++ ABI: ${ABI} (C++$([ "${ABI}" == "4" ] && echo "98" || echo "11"))"
+    echo "    GLIBC is: $(getconf GNU_LIBC_VERSION)"
+    echo "    ld/binutils is: $(ld --version | head -1)"
+    echo
+    echo "    Native arch is x86_64.  ${ARCH_DOC}"
+    echo
+    echo "    The dev user (currently signed in) has passwordless sudo access."
+    echo "    miniconda (2.7) is installed at /opt/miniconda."
+    echo "    git is also available."
+
+    if [ -f "/home/dev/.gitconfig" ]; then
+        echo "    Your .gitconfig has been imported."
+    fi
+
+    if [ -f /id_rsa ]; then
+        echo "    Your ssh private key has been imported for passwordless ssh."
+    fi
+
+    echo
+
+    echo "Helpful aliases:"
+    echo "    clone_recipes: clones the conda/conda-recipes repo from Github"
+    echo "    clone_anaconda: clones the continuumIO/anaconda (private) repo from Github"
+    echo "    anaconda_setup: clones anaconda repo and sets up continuum internal build system."
+
+    echo
+
     bash
 else
     # Run whatever the user wants to pass in


### PR DESCRIPTION
cc @dsludwig @PeterDSteinberg - this adds your sudo fix, plus makes output only show up if the run script is not passed any build command.  Please let me know if this solves your issues.

Also, word of advice: if you pass --rm to the run script, then the docker container will clean itself up and remove itself when it's done.  You probably want that, if you don't already do something to clean them up.  They will otherwise build up over time and needlessly consume disk space.