### PR TITLE
builder: save size; symlinks in /usr/lib*

### DIFF
--- a/centos5_gcc5_base/Dockerfile
+++ b/centos5_gcc5_base/Dockerfile
@@ -2,14 +2,9 @@ FROM centos:5.11
 MAINTAINER Michael Sarahan <msarahan@continuum.io>
 
 WORKDIR /build_scripts
-COPY install_yum_deps.sh build_gcc.sh yum_cleanup.sh /build_scripts/
+COPY install_yum_deps.sh build_gcc.sh yum_cleanup.sh symlink_libraries.sh /build_scripts/
 RUN bash install_yum_deps.sh && \
     bash build_gcc.sh && \
     bash yum_cleanup.sh && \
+    bash symlink_libraries.sh && \
     rm -rf /build_scripts
-# replace ancient system libstdc++, plug ours in.
-# This is a workaround for some recipes that do not respect LIBRARY_PATH.
-RUN ln -sf /usr/local/lib64/libstdc++.so.6.0.21 /usr/lib64/libstdc++.so.6
-RUN ln -sf /usr/local/lib/libstdc++.so.6.0.21 /usr/lib/libstdc++.so.6
-RUN ln -sf /usr/local/lib64/libgcc_s.so.1 /usr/lib64/libgcc_s.so.1
-RUN ln -sf /usr/local/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1

--- a/centos5_gcc5_base/symlink_libraries.sh
+++ b/centos5_gcc5_base/symlink_libraries.sh
@@ -1,0 +1,18 @@
+# replace ancient system libstdc++, plug ours in.
+# This is a workaround for some recipes that do not respect LIBRARY_PATH.
+
+libraries=(libstdc++.so.6.0.21 libstdc++.so.6 libstdc++.so
+           libgcc_s.so.1 libgcc_s.so
+           libgomp.so.1.0.0 libgomp.so.1 libgomp.so
+           libgfortran.so.3.0.0 libgfortran.so.3 libgfortran.so
+           libquadmath.so.0.0.0 libquadmath.so.0 libquadmath.so)
+folders=(lib lib64)
+
+for folder in "${folders[@]}"
+do
+    for library in "${libraries[@]}"
+    do
+        rm -f /usr/$folder/$library
+        ln -s /usr/local/$folder/$library /usr/$folder/$library
+    done
+done

--- a/conda_builder_linux/Dockerfile
+++ b/conda_builder_linux/Dockerfile
@@ -1,4 +1,4 @@
-from continuumio/centos5_gcc5_base:5.11-5.2-0
+from continuumio/centos5_gcc5_base:5.11-5.2-1
 MAINTAINER Michael Sarahan <msarahan@continuum.io>
 
 WORKDIR /build_scripts
@@ -10,26 +10,18 @@ COPY build/yum_install_syslibs.sh \
 RUN bash yum_install_syslibs.sh && \
     bash install_miniconda.sh && \
     bash yum_cleanup.sh && \
-    rm -rf /build_scripts
+    rm -rf /build_scripts && \
+    mkdir -p /opt/share && \
+    mkdir -p /opt/miniconda/conda-bld/work/linux-64 && \
+    mkdir -p /opt/miniconda/conda-bld/work/linux-32 && \
+    mkdir -p /opt/miniconda/conda-bld/work/noarch && \
+    chmod -R 777 /opt && \
+    useradd -m --uid 1000 -G wheel dev && \
+    echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo 'Defaults:%wheel !requiretty' >> /etc/sudoers
 
-# Yum may have messed up symlinks to libstdc++.  Make sure they are still ours.
-RUN ln -sf /usr/local/lib64/libstdc++.so.6.0.21 /usr/lib64/libstdc++.so.6 && \
-    ln -sf /usr/local/lib/libstdc++.so.6.0.21 /usr/lib/libstdc++.so.6 && \
-    ln -sf /usr/local/lib64/libgcc_s.so.1 /usr/lib64/libgcc_s.so.1 && \
-    ln -sf /usr/local/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
-
-RUN useradd -m --uid 1000 -G wheel dev
-
-RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-  echo 'Defaults:%wheel !requiretty' >> /etc/sudoers
-
-# this is where we'll mount shares from the user
-RUN mkdir -p /opt/share
 ADD build/internal_startup.sh /opt/share/internal_startup.sh
 ADD build/alias_32bit.sh /opt/share/alias_32bit.sh
-RUN mkdir -p /opt/miniconda/conda-bld/work/linux-64
-RUN mkdir -p /opt/miniconda/conda-bld/work/linux-32
-RUN chmod -R 777 /opt
 
 WORKDIR /home/dev
 USER dev


### PR DESCRIPTION
Compress filesize thanks to @dsludwig suggestion by moving chmod up to earlier run section.  Also fixes some errors seen because of system libraries in /usr/lib being the old versions.  Symlinks new versions to replace them.