### PR TITLE
Add support for CUDA-enabled images (using nvidia-docker).

### DIFF
--- a/conda_builder_linux/Dockerfile.cuda
+++ b/conda_builder_linux/Dockerfile.cuda
@@ -1,0 +1,32 @@
+# This is a clone of ./Dockerfile, but layered over a different base image
+# to include a CUDA 7.5 development environment.
+
+FROM nvidia/cuda:7.5-devel-centos6
+MAINTAINER Stefan Seefeld <sseefeld@continuum.io>
+
+WORKDIR /build_scripts
+COPY build/install_yum_deps.sh \
+     build/yum_install_syslibs.sh \
+     build/install_miniconda.sh \
+     build/yum_cleanup.sh \
+     /build_scripts/
+
+RUN bash install_yum_deps.sh && \
+    bash yum_install_syslibs.sh && \
+    bash install_miniconda.sh && \
+    bash yum_cleanup.sh && \
+    rm -rf /build_scripts && \
+    mkdir -p /opt/share && \
+    mkdir -p /opt/miniconda/conda-bld/work/linux-64 && \
+    mkdir -p /opt/miniconda/conda-bld/work/linux-32 && \
+    mkdir -p /opt/miniconda/conda-bld/work/noarch && \
+    chmod -R 777 /opt && \
+    useradd -m --uid 1000 -G wheel dev && \
+    echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo 'Defaults:%wheel !requiretty' >> /etc/sudoers
+
+ADD build/internal_startup.sh /opt/share/internal_startup.sh
+ADD build/alias_32bit.sh /opt/share/alias_32bit.sh
+
+WORKDIR /home/dev
+USER dev

--- a/conda_builder_linux/build/install_yum_deps.sh
+++ b/conda_builder_linux/build/install_yum_deps.sh
@@ -1,0 +1,5 @@
+yum install -y curl.x86_64 bzip2.x86_64 yum-utils glibc-devel glibc-devel.i686 libstdc++.i686 patch \
+    unzip bison yasm file make libtool.x86_64 pkgconfig.x86_64
+curl http://linuxsoft.cern.ch/cern/devtoolset/slc5-devtoolset.repo -o /etc/yum.repos.d/slc5-devtoolset.repo
+rpm --import http://ftp.mirrorservice.org/sites/ftp.scientificlinux.org/linux/scientific/51/i386/RPM-GPG-KEYs/RPM-GPG-KEY-cern
+yum install -y centos-release-scl devtoolset-3

--- a/conda_builder_linux/docker_wrapper.sh
+++ b/conda_builder_linux/docker_wrapper.sh
@@ -6,6 +6,7 @@
 #    know how to tweak docker run
 
 # parse options and pick off docker-run options
+DOCKER=docker
 DOCKER_ARGS=()
 IMAGE="continuumio/conda_builder_linux:latest"
 while [[ $# > 0 ]]
@@ -16,6 +17,9 @@ do
 	-I|--image)
 	    IMAGE="$2"
 	    shift # past argument
+	    ;;
+	--nvidia)
+	    DOCKER=nvidia-docker
 	    ;;
         -d)
             # start in detached mode
@@ -62,4 +66,4 @@ docker_run_string+="${DOCKER_ARGS[@]} "
 docker_run_string+="$IMAGE "
 docker_run_string+="bash /opt/share/internal_startup.sh $@"
 
-docker ${docker_run_string}
+${DOCKER} ${docker_run_string}


### PR DESCRIPTION
This patch allows me to

1) build a docker image very much like conda_builder_linux but layered over a CUDA-7.5-enabled centos-7

2) run that using the existing scripts, simply by adding a `--nvidia` flag (which will pick `nvidia-docker` over `docker` to run the image).
