### PR TITLE
Update Docker images/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+Docker images for Anaconda/Miniconda that are available from Docker Hub:
+
+https://hub.docker.com/r/continuumio/
+
+Documentation for Anaconda Integrations, including Docker:
+
+https://docs.continuum.io/anaconda/images

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-You might be interested in this documentation: http://docs.continuum.io/anaconda/images.html

--- a/anaconda/Dockerfile
+++ b/anaconda/Dockerfile
@@ -1,14 +1,17 @@
-FROM debian:7.4
+FROM debian:8.5
 
 MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     git mercurial subversion
+
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/archive/Anaconda2-4.0.0-Linux-x86_64.sh && \
-    /bin/bash /Anaconda2-4.0.0-Linux-x86_64.sh -b -p /opt/conda && \
-    rm /Anaconda2-4.0.0-Linux-x86_64.sh
+    wget --quiet https://repo.continuum.io/archive/Anaconda-4.0.0-Linux-x86_64.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh
 
 RUN apt-get install -y curl grep sed dpkg && \
     TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
@@ -18,10 +21,6 @@ RUN apt-get install -y curl grep sed dpkg && \
     apt-get clean
 
 ENV PATH /opt/conda/bin:$PATH
-
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/anaconda/Dockerfile
+++ b/anaconda/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/archive/Anaconda-4.0.0-Linux-x86_64.sh -O ~/anaconda.sh && \
+    wget --quiet https://repo.continuum.io/archive/Anaconda2-4.0.0-Linux-x86_64.sh -O ~/anaconda.sh && \
     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
     rm ~/anaconda.sh
 

--- a/anaconda/README.md
+++ b/anaconda/README.md
@@ -1,17 +1,32 @@
 # docker-anaconda
 
-Docker container with a bootstrapped [anaconda](https://store.continuum.io/cshop/anaconda/) installed and ready to use.
+Docker container with a bootstrapped installation of
+[Anaconda](http://continuum.io/downloads) (based on Python 2.7) that is ready
+to use.
 
-This installs whole anaconda python distribution (with native python in 2.7 version) into the ``/opt/conda`` environment
-and ensures that the default user has ``conda`` tool on their path.
+The Anaconda distribution is installed into the `/opt/conda` folder and ensures
+that the default user has the `conda` command in their path.
 
+Anaconda is the leading open data science platform powered by Python. The open
+source version of Anaconda is a high performance distribution and includes over
+100 of the most popular Python packages for data science. Additionally, it
+provides access to over 720 Python and R packages that can easily be installed
+using the conda dependency and environment manager, which is included in
+Anaconda.
 
 Usage
 -----
-You can download and use this image by pulling it:
+
+You can download and run this image using the following commands:
 
     docker pull continuumio/anaconda
     docker run -i -t continuumio/anaconda /bin/bash
 
+Alternatively, you can start a Jupyter Notebook server and interact with
+Anaconda via your browser:
 
-[anaconda]: http://docs.continuum.io/anaconda/index.html
+    docker run -i -t -p 8888:8888 continuumio/anaconda /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+
+You can then view the Jupyter Notebook by opening `http://localhost:8888` in
+your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker
+Machine VM.

--- a/anaconda3/Dockerfile
+++ b/anaconda3/Dockerfile
@@ -1,14 +1,17 @@
-FROM debian:7.4
+FROM debian:8.5
 
 MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     git mercurial subversion
+
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/archive/Anaconda3-4.0.0-Linux-x86_64.sh && \
-    /bin/bash /Anaconda3-4.0.0-Linux-x86_64.sh -b -p /opt/conda && \
-    rm /Anaconda3-4.0.0-Linux-x86_64.sh
+    wget --quiet https://repo.continuum.io/archive/Anaconda3-4.0.0-Linux-x86_64.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh
 
 RUN apt-get install -y curl grep sed dpkg && \
     TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
@@ -18,10 +21,6 @@ RUN apt-get install -y curl grep sed dpkg && \
     apt-get clean
 
 ENV PATH /opt/conda/bin:$PATH
-
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/anaconda3/README.md
+++ b/anaconda3/README.md
@@ -1,17 +1,32 @@
 # docker-anaconda
 
-Docker container with a bootstrapped [anaconda3](https://store.continuum.io/cshop/anaconda/) installed and ready to use.
+Docker container with a bootstrapped installation of
+[Anaconda](http://continuum.io/downloads) (based on Python 3.5) that is ready
+to use.
 
-This installs whole anaconda python distribution (with native python in 3.4 version) into the ``/opt/conda`` environment
-and ensures that the default user has ``conda`` tool on their path.
+The Anaconda distribution is installed into the `/opt/conda` folder and ensures
+that the default user has the `conda` command in their path.
 
+Anaconda is the leading open data science platform powered by Python. The open
+source version of Anaconda is a high performance distribution and includes over
+100 of the most popular Python packages for data science. Additionally, it
+provides access to over 720 Python and R packages that can easily be installed
+using the conda dependency and environment manager, which is included in
+Anaconda.
 
 Usage
 -----
-You can download and use this image by pulling it:
+
+You can download and run this image using the following commands:
 
     docker pull continuumio/anaconda3
     docker run -i -t continuumio/anaconda3 /bin/bash
 
+Alternatively, you can start a Jupyter Notebook server and interact with
+Anaconda via your browser:
 
-[anaconda]: http://docs.continuum.io/anaconda/index.html
+    docker run -i -t -p 8888:8888 continuumio/anaconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+
+You can then view the Jupyter Notebook by opening `http://localhost:8888` in
+your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker
+Machine VM.

--- a/miniconda/Dockerfile
+++ b/miniconda/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda-4.0.5-Linux-x86_64.sh -O ~/miniconda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda2-4.0.5-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh
 

--- a/miniconda/Dockerfile
+++ b/miniconda/Dockerfile
@@ -1,14 +1,17 @@
-FROM debian:7.4
+FROM debian:8.5
 
 MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     git mercurial subversion
+
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda2-4.0.5-Linux-x86_64.sh && \
-    /bin/bash /Miniconda2-4.0.5-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniconda2-4.0.5-Linux-x86_64.sh
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda-4.0.5-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
 
 RUN apt-get install -y curl grep sed dpkg && \
     TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
@@ -18,10 +21,6 @@ RUN apt-get install -y curl grep sed dpkg && \
     apt-get clean
 
 ENV PATH /opt/conda/bin:$PATH
-
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/miniconda/README.md
+++ b/miniconda/README.md
@@ -1,17 +1,32 @@
 # docker-miniconda
 
-Docker container with a bootstrapped [miniconda](http://conda.pydata.org/miniconda.html) installed and ready to use.
+Docker container with a bootstrapped installation of
+[Miniconda](http://conda.pydata.org/miniconda.html) (based on Python 2.7) that
+is ready to use.
 
-This installs ``conda`` and Python 2.7 into the ``/opt/conda`` environment
-and ensures that the default user has that on their path.
+The Miniconda distribution is installed into the `/opt/conda` folder and ensures
+that the default user has the `conda` command in their path.
 
+Anaconda is the leading open data science platform powered by Python. The open
+source version of Anaconda is a high performance distribution and includes over
+100 of the most popular Python packages for data science. Additionally, it
+provides access to over 720 Python and R packages that can easily be installed
+using the conda dependency and environment manager, which is included in
+Anaconda.
 
 Usage
 -----
-You can download and use this image by pulling it:
+
+You can download and run this image using the following commands:
 
     docker pull continuumio/miniconda
     docker run -i -t continuumio/miniconda /bin/bash
 
+Alternatively, you can start a Jupyter Notebook server and interact with
+Miniconda via your browser:
 
-[miniconda]: http://conda.pydata.org/miniconda.html
+    docker run -i -t -p 8888:8888 continuumio/miniconda /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+
+You can then view the Jupyter Notebook by opening `http://localhost:8888` in
+your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker
+Machine VM.

--- a/miniconda3/Dockerfile
+++ b/miniconda3/Dockerfile
@@ -1,14 +1,17 @@
-FROM debian:7.4
+FROM debian:8.5
 
 MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     git mercurial subversion
+
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.0.5-Linux-x86_64.sh && \
-    /bin/bash /Miniconda3-4.0.5-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniconda3-4.0.5-Linux-x86_64.sh
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.0.5-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
 
 RUN apt-get install -y curl grep sed dpkg && \
     TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
@@ -18,10 +21,6 @@ RUN apt-get install -y curl grep sed dpkg && \
     apt-get clean
 
 ENV PATH /opt/conda/bin:$PATH
-
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 CMD [ "/bin/bash" ]

--- a/miniconda3/README.md
+++ b/miniconda3/README.md
@@ -1,17 +1,32 @@
 # docker-miniconda
 
-Docker container with a bootstrapped [miniconda3](http://conda.pydata.org/miniconda.html) installed and ready to use.
+Docker container with a bootstrapped installation of
+[Miniconda](http://conda.pydata.org/miniconda.html) (based on Python 3.5) that
+is ready to use.
 
-This installs ``conda`` and Python 3.4 into the ``/opt/conda`` environment
-and ensures that the default user has that on their path.
+The Miniconda distribution is installed into the `/opt/conda` folder and ensures
+that the default user has the `conda` command in their path.
 
+Anaconda is the leading open data science platform powered by Python. The open
+source version of Anaconda is a high performance distribution and includes over
+100 of the most popular Python packages for data science. Additionally, it
+provides access to over 720 Python and R packages that can easily be installed
+using the conda dependency and environment manager, which is included in
+Anaconda.
 
 Usage
 -----
-You can download and use this image by pulling it:
+
+You can download and run this image using the following commands:
 
     docker pull continuumio/miniconda3
     docker run -i -t continuumio/miniconda3 /bin/bash
 
+Alternatively, you can start a Jupyter Notebook server and interact with
+Miniconda via your browser:
 
-[miniconda]: http://conda.pydata.org/miniconda.html
+    docker run -i -t -p 8888:8888 continuumio/miniconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+
+You can then view the Jupyter Notebook by opening `http://localhost:8888` in
+your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker
+Machine VM.


### PR DESCRIPTION
* Update to Debian 8.5 base image
* Add Jupyter notebook installation and startup
* Remove unused libraries/commands
* Update description and usage in README

@mutirri, can you review these changes? We can iterate on this image first, then I can update the other images (anaconda, anaconda3, miniconda). Note that the updated base image and removed libraries were based on the results of the [Docker security scan](https://docs.docker.com/docker-cloud/builds/image-scan/).