### PR TITLE
[WIP] add conda-concourse-ci

### DIFF
--- a/conda-concourse-ci/Dockerfile
+++ b/conda-concourse-ci/Dockerfile
@@ -1,0 +1,11 @@
+FROM continuumio/miniconda3
+
+MAINTAINER Michael Sarahan <msarahan@continuum.io>
+
+RUN conda update -y --all && conda install -y -c msarahan conda-build conda-concourse-ci && conda clean -pty
+RUN mkdir -p bin && curl -L https://github.com/concourse/concourse/releases/download/v2.5.0/fly_linux_amd64 -o bin/fly && chmod +x bin/fly
+RUN echo "export PATH=$PATH:~/bin" >> ~/.bashrc
+RUN echo "add_pip_as_python_dependency: False" >> ~/.condarc
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This is a docker image used by the Concourse build system, currently under construction.

This image contains miniconda and the conda-concourse-ci package, which is used to compute necessary builds and submit them to the build system.

This PR currently draws that package from my personal channel, because there is not an official release yet.  This PR will be adapted when that release happens.