### PR TITLE
Add files for Power8 Docker containers

### DIFF
--- a/ppc64le/anaconda/Dockerfile
+++ b/ppc64le/anaconda/Dockerfile
@@ -1,0 +1,18 @@
+FROM ppc64le/debian:8
+
+MAINTAINER Jonathan J. Helmus <jhelmus@continuum.io>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libgomp1 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/archive/Anaconda2-4.4.0.1-Linux-ppc64le.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh
+
+ENV PATH /opt/conda/bin:$PATH
+
+CMD [ "/bin/bash" ]

--- a/ppc64le/anaconda/LICENSE
+++ b/ppc64le/anaconda/LICENSE
@@ -1,0 +1,26 @@
+Except where noted below, docker-anaconda is released under the following terms:
+
+(c) 2012 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ppc64le/anaconda/README.md
+++ b/ppc64le/anaconda/README.md
@@ -1,0 +1,23 @@
+# docker-anaconda
+
+Docker container with a bootstrapped installation of [Anaconda](http://continuum.io/downloads) (based on Python 2.7) for Power8 that is ready to use.
+
+Power8 Docker containers are provided as beta products, long-term support of these containers is not defined at this time.
+
+The Anaconda distribution is installed into the `/opt/conda` folder and ensures that the default user has the `conda` command in their path.
+
+Anaconda is the leading open data science platform powered by Python. The open source version of Anaconda is a high performance distribution and includes over 100 of the most popular Python packages for data science. Additionally, it provides access to over 720 Python and R packages that can easily be installed using the conda dependency and environment manager, which is included in Anaconda.
+
+Usage
+-----
+
+You can download and run this image using the following commands:
+
+    docker pull continuumio/anaconda_ppc64le
+    docker run -i -t continuumio/anaconda_ppc64le /bin/bash
+
+Alternatively, you can start a Jupyter Notebook server and interact with Anaconda via your browser:
+
+    docker run -i -t -p 8888:8888 continuumio/anaconda_ppc64le /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+
+You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker Machine VM.

--- a/ppc64le/anaconda3/Dockerfile
+++ b/ppc64le/anaconda3/Dockerfile
@@ -1,0 +1,18 @@
+FROM ppc64le/debian:8
+
+MAINTAINER Jonathan J. Helmus <jhelmus@continuum.io>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libgomp1 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/archive/Anaconda3-4.4.0.1-Linux-ppc64le.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh
+
+ENV PATH /opt/conda/bin:$PATH
+
+CMD [ "/bin/bash" ]

--- a/ppc64le/anaconda3/LICENSE
+++ b/ppc64le/anaconda3/LICENSE
@@ -1,0 +1,26 @@
+Except where noted below, docker-anaconda is released under the following terms:
+
+(c) 2012 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ppc64le/anaconda3/README.md
+++ b/ppc64le/anaconda3/README.md
@@ -1,0 +1,23 @@
+# docker-anaconda
+
+Docker container with a bootstrapped installation of [Anaconda](http://continuum.io/downloads) (based on Python 3.6) for Power 8 that is ready to use.
+
+Power8 Docker containers are provided as beta products, long-term support of these containers is not defined at this time.
+
+The Anaconda distribution is installed into the `/opt/conda` folder and ensures that the default user has the `conda` command in their path.
+
+Anaconda is the leading open data science platform powered by Python. The open source version of Anaconda is a high performance distribution and includes over 100 of the most popular Python packages for data science. Additionally, it provides access to over 720 Python and R packages that can easily be installed using the conda dependency and environment manager, which is included in Anaconda.
+
+Usage
+-----
+
+You can download and run this image using the following commands:
+
+    docker pull continuumio/anaconda3_ppc64le
+    docker run -i -t continuumio/anaconda3_ppc64le /bin/bash
+
+Alternatively, you can start a Jupyter Notebook server and interact with Anaconda via your browser:
+
+    docker run -i -t -p 8888:8888 continuumio/anaconda3_ppc64le /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+
+You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker Machine VM.

--- a/ppc64le/miniconda/Dockerfile
+++ b/ppc64le/miniconda/Dockerfile
@@ -1,0 +1,18 @@
+FROM ppc64le/debian:8
+
+MAINTAINER Jonathan J. Helmus <jhelmus@continuum.io>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libgomp1 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda2-4.3.14-Linux-ppc64le.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
+
+ENV PATH /opt/conda/bin:$PATH
+
+CMD [ "/bin/bash" ]

--- a/ppc64le/miniconda/LICENSE
+++ b/ppc64le/miniconda/LICENSE
@@ -1,0 +1,26 @@
+Except where noted below, docker-miniconda is released under the following terms:
+
+(c) 2012 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ppc64le/miniconda/README.md
+++ b/ppc64le/miniconda/README.md
@@ -1,0 +1,23 @@
+# docker-miniconda
+
+Docker container with a bootstrapped installation of [Miniconda](http://conda.pydata.org/miniconda.html) (based on Python 2.7) for Power8 that is ready to use.
+
+Power8 Docker containers are provided as beta products, long-term support of these containers is not defined at this time.
+
+The Miniconda distribution is installed into the `/opt/conda` folder and ensures that the default user has the `conda` command in their path.
+
+Anaconda is the leading open data science platform powered by Python. The open source version of Anaconda is a high performance distribution and includes over 100 of the most popular Python packages for data science. Additionally, it provides access to over 720 Python and R packages that can easily be installed using the conda dependency and environment manager, which is included in Anaconda.
+
+Usage
+-----
+
+You can download and run this image using the following commands:
+
+    docker pull continuumio/miniconda_ppc64le
+    docker run -i -t continuumio/miniconda_ppc64le /bin/bash
+
+Alternatively, you can start a Jupyter Notebook server and interact with Miniconda via your browser:
+
+    docker run -i -t -p 8888:8888 continuumio/miniconda_ppc64le /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+
+You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker Machine VM.

--- a/ppc64le/miniconda3/Dockerfile
+++ b/ppc64le/miniconda3/Dockerfile
@@ -1,0 +1,18 @@
+FROM ppc64le/debian:8
+
+MAINTAINER Jonathan J. Helmus <jhelmus@continuum.io>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libgomp1 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.3.14-Linux-ppc64le.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
+
+ENV PATH /opt/conda/bin:$PATH
+
+CMD [ "/bin/bash" ]

--- a/ppc64le/miniconda3/LICENSE
+++ b/ppc64le/miniconda3/LICENSE
@@ -1,0 +1,26 @@
+Except where noted below, docker-miniconda is released under the following terms:
+
+(c) 2012 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ppc64le/miniconda3/README.md
+++ b/ppc64le/miniconda3/README.md
@@ -1,0 +1,23 @@
+# docker-miniconda
+
+Docker container with a bootstrapped installation of [Miniconda](http://conda.pydata.org/miniconda.html) (based on Python 3.6) for Power8 that is ready to use.
+
+Power8 Docker containers are provided as beta products, long-term support of these containers is not defined at this time.
+
+The Miniconda distribution is installed into the `/opt/conda` folder and ensures that the default user has the `conda` command in their path.
+
+Anaconda is the leading open data science platform powered by Python. The open source version of Anaconda is a high performance distribution and includes over 100 of the most popular Python packages for data science. Additionally, it provides access to over 720 Python and R packages that can easily be installed using the conda dependency and environment manager, which is included in Anaconda.
+
+Usage
+-----
+
+You can download and run this image using the following commands:
+
+    docker pull continuumio/miniconda3_ppc64le
+    docker run -i -t continuumio/miniconda3_ppc64le /bin/bash
+
+Alternatively, you can start a Jupyter Notebook server and interact with Miniconda via your browser:
+
+    docker run -i -t -p 8888:8888 continuumio/miniconda3_ppc64le /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+
+You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker Machine VM.


### PR DESCRIPTION
Adds files for building anaconda, anaconda3, miniconda, and miniconda3 docker
container for the Power8 (ppc64le) platform.

README.md files indicate that these container are provides as a beta with
uncertain long term support.