### PR TITLE
add  --allow-root  Alternatively start

### DIFF
--- a/anaconda3/README.md
+++ b/anaconda3/README.md
@@ -16,6 +16,6 @@ You can download and run this image using the following commands:
 
 Alternatively, you can start a Jupyter Notebook server and interact with Anaconda via your browser:
 
-    docker run -i -t -p 8888:8888 continuumio/anaconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser --allow-root"
+    docker run -i -t -p 8888:8888 continuumio/anaconda3 /bin/bash -c "useradd dev --create-home && mkdir /opt/notebooks && chown dev:dev /opt/notebooks && su - dev -c \"/opt/conda/bin/conda install jupyter -y --quiet && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser\""
 
 You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker Machine VM.

--- a/anaconda3/README.md
+++ b/anaconda3/README.md
@@ -16,6 +16,6 @@ You can download and run this image using the following commands:
 
 Alternatively, you can start a Jupyter Notebook server and interact with Anaconda via your browser:
 
-    docker run -i -t -p 8888:8888 continuumio/anaconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
+    docker run -i -t -p 8888:8888 continuumio/anaconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser --allow-root"
 
 You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker Machine VM.


### PR DESCRIPTION
don't start   "Alternatively, you can start a Jupyter Notebook server and interact with Anaconda via your browser"

log
"Running as root is not recommended. Use --allow-root to bypass."