### PR TITLE
Update miniconda to 4.3.30

### DIFF
--- a/miniconda3/Dockerfile
+++ b/miniconda3/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.3.27-Linux-x86_64.sh -O ~/miniconda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh
 


### PR DESCRIPTION
This is badly needed because of https://github.com/ContinuumIO/anaconda-issues/issues/6232.  This would fix https://github.com/ContinuumIO/docker-images/issues/68.