### PR TITLE
Update miniconda3 Dockerfile

### DIFF
--- a/miniconda3/Dockerfile
+++ b/miniconda3/Dockerfile
@@ -1,24 +1,21 @@
 FROM debian:8
 
-MAINTAINER Kamil Kwiek <kamil.kwiek@continuum.io>
-
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
-    libglib2.0-0 libxext6 libsm6 libxrender1 \
-    git mercurial subversion
+RUN apt-get update --fix-missing && \
+    apt-get install -y wget bzip2 ca-certificates curl git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.3.27-Linux-x86_64.sh -O ~/miniconda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda clean -tipsy
 
-RUN apt-get install -y curl grep sed dpkg && \
-    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
-    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
-    dpkg -i tini.deb && \
-    rm tini.deb && \
-    apt-get clean
+ENV TINI_VERSION v0.16.1
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
 
 ENV PATH /opt/conda/bin:$PATH
 


### PR DESCRIPTION
This does the following:

1.  Remove listed maintainer
2.  Remove a few of the apt packages, also clear lists
3.  Update miniconda to 4.3.31
4.  Call `conda clean -tipsy` at the end of the conda line
5.  Replace TINI dpkg installation with solution suggested here:

    https://github.com/krallin/tini#using-tini

This is untested and includes removing some packages.  This is up here for review.