### PR TITLE
build_anaconda abstracts out continuumio as the repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ Documentation for Anaconda Integrations, including Docker:
 
 https://docs.anaconda.com/anaconda/user-guide/tasks/docker/
 
+The latest version is 2019.03 or check https://www.anaconda.com/distribution/ to
+see what it is. When you are ready, you can push.
+
 Push All:
 
 ```
 docker push continuumio/anaconda:latest
-docker push continuumio/anaconda:5.2.0
+docker push continuumio/anaconda:2019.03
 docker push continuumio/anaconda2:latest
-docker push continuumio/anaconda2:5.2.0
+docker push continuumio/anaconda2:2019.03
 docker push continuumio/anaconda3:latest
-docker push continuumio/anaconda3:5.2.0
+docker push continuumio/anaconda3:2019.03
 docker push continuumio/miniconda:latest
 docker push continuumio/miniconda:4.5.4
 docker push continuumio/miniconda2:latest
@@ -26,6 +29,9 @@ docker push continuumio/miniconda3:4.5.4
 ```
 
 ## How to build anaconda images
+The build version is required and the latest one is 2019.03. You can also
+specify a Docker repo namespace that is different that continuumio if you like
+by adding a `-r docker_namespace` to the command.
 
 1. Update the version in `anaconda/**/Dockerfile` and `anaconda3/**/Dockerfile`
 2. cd to scripts

--- a/scripts/build_anaconda.sh
+++ b/scripts/build_anaconda.sh
@@ -1,21 +1,27 @@
 #!/bin/bash
 
 function usage {
-    echo -e "Usage: ./build_anaconda.sh -v version \n"
+    echo -e "Usage: ./build_anaconda.sh -v version [-r repository] \n"
     exit 1
 }
+REPO="continuumio"
 
 while [[ $# -gt 0 ]]
 do
 key="$1"
 
 case $key in
-    -v|--version)
+  -v|--version)
     VERSION="$2"
     shift
     shift
     ;;
-    *)
+  -r|--repository)
+    REPO="$2"
+    shift
+    shift
+    ;;
+  *)
     usage
     exit 0
     shift
@@ -28,23 +34,23 @@ cd ..
 echo "ANACONDA ALPINE"
 
 pushd anaconda/alpine
-docker build . -t continuumio/anaconda:$VERSION-alpine
+docker build . -t "$REPO/anaconda:$VERSION-alpine"
 popd
 
 echo "ANACONDA DEBIAN"
 
 pushd anaconda/debian
-docker build . -t continuumio/anaconda:$VERSION -t continuumio/anaconda:latest
+docker build . -t $REPO/anaconda:$VERSION -t $REPO/anaconda:latest
 popd
 
 echo "ANACONDA3 ALPINE"
 
 pushd anaconda3/alpine
-docker build . -t continuumio/anaconda3:$VERSION-alpine
+docker build . -t $REPO/anaconda3:$VERSION-alpine
 popd
 
 echo "ANACONDA3 DEBIAN"
 
 pushd anaconda3/debian
-docker build . -t continuumio/anaconda3:$VERSION -t continuumio/anaconda3:latest
+docker build . -t $REPO/anaconda3:$VERSION -t $REPO/anaconda3:latest
 popd


### PR DESCRIPTION
Right now the build script is hardcoded to go to the continuumio docker hub. This abstracts out this to the default there, but if you utter

```
cd scripts
bash build_anaconda.sh -v 2019.03 -r tongfamily
```

Then it will automatically tag things it `tongfamily` as the Docker repo namspace instead. This is useful for folks who want to do a full fork and have a stable build