### PR TITLE
Ensure that the conda bin folder is in the PATH

### DIFF
--- a/miniconda3/alpine/Dockerfile
+++ b/miniconda3/alpine/Dockerfile
@@ -71,6 +71,6 @@ RUN addgroup -S anaconda && \
 
 
 USER  10151
-ENV PATH "/bin:/sbin:/usr/bin"
+ENV PATH "/opt/conda/bin:/bin:/sbin:/usr/bin"
 
 CMD [ "sh", "--login", "-i" ]


### PR DESCRIPTION
The current Alpine version of your miniconda3 dockerfile has neither conda nor python in the PATH. This change should remedy that.