### PR TITLE
add PATH to debian images

### DIFF
--- a/anaconda/debian/Dockerfile
+++ b/anaconda/debian/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster-slim
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
 
 RUN apt-get update --fix-missing && \
     apt-get install -y wget bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 git mercurial subversion && \

--- a/anaconda3/debian/Dockerfile
+++ b/anaconda3/debian/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster-slim
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
 
 RUN apt-get update --fix-missing && \
     apt-get install -y wget bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 git mercurial subversion && \

--- a/miniconda/debian/Dockerfile
+++ b/miniconda/debian/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster-slim
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
 
 RUN apt-get update --fix-missing && \
     apt-get install -y wget bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 git mercurial subversion && \

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster-slim
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
 
 RUN apt-get update --fix-missing && \
     apt-get install -y wget bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 git mercurial subversion && \


### PR DESCRIPTION
`/opt/conda/bin` has been removed from PATH since 2019.07 version (#135).
Because of that, I can't build Dockerfile such as bellow.

``` Dockerfile
FROM continuumio/anaconda3:2019.07

RUN conda install -y cudatoolkit
# /bin/sh: 1: conda: not found
```

I don't know why `/opt/conda/bin` has been removed from PATH, Is this behavior a bug?
I think it's OK to use the `conda` and `pip` commands without an explicit `conda activate`.

related: #136 #138