### PR TITLE
Update CI images to install packages from defaults

### DIFF
--- a/conda_ci/conda-ci-linux-64-python2.7/Dockerfile
+++ b/conda_ci/conda-ci-linux-64-python2.7/Dockerfile
@@ -22,19 +22,16 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86
     /opt/conda/bin/conda clean -tipsy
 
 # conda and test dependencies
-RUN /opt/conda/bin/conda install -y -c conda-canary -c defaults \
+RUN /opt/conda/bin/conda install -y -c defaults \
     conda conda-package-handling \
     python=$PYTHON_VERSION pycosat requests ruamel_yaml cytoolz \
     anaconda-client nbformat make \
-    pytest pytest-cov pytest-timeout mock responses pexpect \
+    pytest pytest-cov codecov radon pytest-timeout mock responses pexpect \
     flake8 enum34 futures && \
     /opt/conda/bin/conda clean --all --yes
 
-RUN /opt/conda/bin/pip install codecov radon \
-  && rm -rf ~root/.cache/pip
-
 # conda-build and test dependencies
-RUN sudo /opt/conda/bin/conda install -y -c conda-canary -c defaults \
+RUN sudo /opt/conda/bin/conda install -y -c defaults \
         conda-build patch git \
         perl pytest-xdist pytest-mock \
         anaconda-client \

--- a/conda_ci/conda-ci-linux-64-python3.7/Dockerfile
+++ b/conda_ci/conda-ci-linux-64-python3.7/Dockerfile
@@ -26,12 +26,9 @@ RUN /opt/conda/bin/conda install -y -c defaults \
     conda conda-package-handling \
     python=$PYTHON_VERSION pycosat requests ruamel_yaml cytoolz \
     anaconda-client nbformat make \
-    pytest pytest-cov radon pytest-timeout mock responses pexpect \
+    pytest pytest-cov codecov radon pytest-timeout mock responses pexpect \
     flake8 && \
     /opt/conda/bin/conda clean --all --yes
-
-RUN /opt/conda/bin/pip install codecov \
-  && rm -rf ~root/.cache/pip
 
 # conda-build and test dependencies
 RUN sudo /opt/conda/bin/conda install -y -c defaults \

--- a/conda_ci/conda-ci-linux-64-python3.8/Dockerfile
+++ b/conda_ci/conda-ci-linux-64-python3.8/Dockerfile
@@ -26,12 +26,9 @@ RUN /opt/conda/bin/conda install -y -c defaults \
     conda conda-package-handling \
     python=$PYTHON_VERSION pycosat requests ruamel_yaml cytoolz \
     anaconda-client nbformat make \
-    pytest pytest-cov radon pytest-timeout mock responses pexpect \
+    pytest pytest-cov codecov radon pytest-timeout mock responses pexpect \
     flake8 && \
     /opt/conda/bin/conda clean --all --yes
-
-RUN /opt/conda/bin/pip install codecov \
-  && rm -rf ~root/.cache/pip
 
 # conda-build and test dependencies
 RUN sudo /opt/conda/bin/conda install -y -c defaults \


### PR DESCRIPTION
Now have version parity for `codecov` and `radon`, so there's really no reason to continue installing these packages from PyPI.