### PR TITLE
Allow manual workflow trigger via GitHub UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'conda_ci/**'
       - '.github/workflows/ci.yml'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This allows to on-demand re-build the conda-ci-linux-64-python* containers