### PR TITLE
Docker images for Anaconda's package building team

### DIFF
--- a/.github/workflows/ana_pkg_build_cicd.yml
+++ b/.github/workflows/ana_pkg_build_cicd.yml
@@ -1,0 +1,83 @@
+name: Build and publish package builder images
+on:
+  pull_request:
+    paths:
+      - 'anaconda-pkg-build/**/Dockerfile'
+      - '.github/workflows/ana_pkg_build_cicd.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/master'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          driver-opts: network=host
+
+      - name: build-push pkg-builder-x86_64
+        uses: docker/build-push-action@v2
+        with:
+          context: ./anaconda-pkg-build/linux
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./anaconda-pkg-build/linux/Dockerfile
+          platform: linux/amd64
+          build-args:
+            - BASEDIST=amd64/centos:7
+            - MC_ARCH=x86_64
+            - GCC_VER=7.3
+          tags: continuumio/c3i-linux-64:cos7
+          push: github.ref == 'refs/heads/master'
+
+      - name: build-push pkg-builder-ppc64le
+        uses: docker/build-push-action@v2
+        with:
+          context: ./anaconda-pkg-build/linux
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./anaconda-pkg-build/linux/Dockerfile
+          platform: linux/ppc64le
+          build-args:
+            - BASEDIST=ppc64le/centos:7
+            - MC_ARCH=ppc64le
+            - GCC_VER=7.3
+          tags: continuumio/c3i-linux-ppc64le:cos7
+          push: github.ref == 'refs/heads/master'
+
+      - name: build-push pkg-builder-aarch64
+        uses: docker/build-push-action@v2
+        with:
+          context: ./anaconda-pkg-build/linux
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./anaconda-pkg-build/linux/Dockerfile
+          platform: linux/arm64/v8
+          build-args:
+            - BASEDIST=arm64v8/centos:7
+            - MC_ARCH=aarch64
+            - GCC_VER=10.2
+          tags: continuumio/c3i-linux-aarch64:cos7
+          push: github.ref == 'refs/heads/master'
+
+      - name: build-push pkg-builder-s390x
+        uses: docker/build-push-action@v2
+        with:
+          context: ./anaconda-pkg-build/linux
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./anaconda-pkg-build/linux/Dockerfile
+          platform: linux/s390x
+          build-args:
+            - BASEDIST=s390x/clefos:7
+            - MC_ARCH=s390x
+            - GCC_VER=7.5
+          tags: continuumio/c3i-linux-s390x:cos7
+          push: github.ref == 'refs/heads/master'

--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -2,8 +2,10 @@
 # packages released on the "defaults" (repo.anaconda.com) channels.
 
 ARG BASEDIST=centos:7
+# hadolint ignore=DL3006
 FROM ${BASEDIST}
 
+# hadolint ignore=DL3031,DL3033
 RUN yum install -q -y deltarpm \
     # Hack to force locale generation, if needed
     && yum update -q -y glibc-common \
@@ -77,6 +79,7 @@ RUN curl -sSL -o /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -bfp /opt/conda \
     && rm -fv /tmp/miniconda.sh
 
+# hadolint ignore=DL3059
 RUN if [ ${MC_ARCH} = "x86_64" ]; then subdir="64"; else subdir="${MC_ARCH}"; fi \
     && /opt/conda/bin/conda update --all --quiet --yes \
     && /opt/conda/bin/conda install --quiet --yes conda-build \
@@ -94,6 +97,7 @@ RUN if [ ${MC_ARCH} = "x86_64" ]; then subdir="64"; else subdir="${MC_ARCH}"; fi
     && /opt/conda/bin/conda install --download-only --quiet --yes \
         gcc_linux-$subdir=${GCC_VER} gxx_linux-$subdir=${GCC_VER}
 
+# hadolint ignore=DL3059
 RUN rm -fv /opt/conda/.condarc \
     && /opt/conda/bin/conda config --system --set show_channel_urls True \
     && /opt/conda/bin/conda config --system --set add_pip_as_python_dependency False \

--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -1,0 +1,104 @@
+# Dockerfile for container images that Anaconda, Inc. uses to build conda
+# packages released on the "defaults" (repo.anaconda.com) channels.
+
+ARG BASEDIST=centos:7
+FROM ${BASEDIST}
+
+RUN yum install -q -y deltarpm \
+    # Hack to force locale generation, if needed
+    && yum update -q -y glibc-common \
+    && yum install -q -y \
+        #----------------------------------------
+        # X11-related libraries needed for various CDTs
+        #----------------------------------------
+        libX11 \
+        libXau \
+        libxcb \
+        libXcomposite \
+        libXcursor \
+        libXdamage \
+        libXdmcp \
+        libXext \
+        libXfixes \
+        libXi \
+        libXinerama \
+        libXrandr \
+        libXrender \
+        libXScrnSaver \
+        libXt \
+        libXtst \
+        #----------------------------------------
+        # MESA 3D graphics library
+        #----------------------------------------
+        #mesa-libEGL \
+        #mesa-libGL \
+        #mesa-libGLU \
+        #----------------------------------------
+        # X11 virtual framebuffer; useful for testing GUI apps
+        #----------------------------------------
+        #xorg-x11-server-Xvfb \
+        #----------------------------------------
+        # Other hardware and low-level system libraries
+        #----------------------------------------
+        #alsa-lib \
+        #libselinux \
+        #pam \
+        #pciutils-libs \
+        #----------------------------------------
+        # Low-level and basic system utilities.
+        #
+        # NOTE: previous versions of this image included tools like `patch`
+        # and `make`; these days, we prefer package recipes list the
+        # equivalent conda packages as build dependencies, rather than
+        # assume the build container provides these tools.
+        #----------------------------------------
+        curl \
+        file \
+        net-tools \
+        openssh-clients \
+        psmisc \
+        rsync \
+        util-linux \
+        #wget \
+        which \
+    && yum clean all
+
+# Set the locale
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+ARG MC_ARCH=$TARGETPLATFORM
+ARG MC_VER=py38_4.9.2
+ARG GCC_VER=7
+
+RUN curl -sSL -o /tmp/miniconda.sh \
+        https://repo.anaconda.com/miniconda/Miniconda3-${MC_VER}-Linux-${MC_ARCH}.sh \
+    && /bin/bash /tmp/miniconda.sh -bfp /opt/conda \
+    && rm -fv /tmp/miniconda.sh
+
+RUN if [ ${MC_ARCH} = "x86_64" ]; then subdir="64"; else subdir="${MC_ARCH}"; fi \
+    && /opt/conda/bin/conda update --all --quiet --yes \
+    && /opt/conda/bin/conda install --quiet --yes conda-build \
+    && /opt/conda/bin/conda clean --all --yes \
+    # Cache our C and C++ compilers so we don't have to download them with
+    # each build; skipping the Fortran compiler as it's not used often
+    # enough to justify the cache space.  Note that we do NOT want to
+    # _actually install_ the compilers in the base environment, as doing so
+    # runs the risk of buggy recipes falling back to those compilers via
+    # `$PATH`, rather than erroring out due to missing compilers in the
+    # `build`/`host` requirements.
+    #
+    # Note, too, that this MUST come _after_ the `conda clean --all` above,
+    # or the compilers will be dumped from the package cache.
+    && /opt/conda/bin/conda install --download-only --quiet --yes \
+        gcc_linux-$subdir=${GCC_VER} gxx_linux-$subdir=${GCC_VER}
+
+RUN rm -fv /opt/conda/.condarc \
+    && /opt/conda/bin/conda config --system --set show_channel_urls True \
+    && /opt/conda/bin/conda config --system --set add_pip_as_python_dependency False \
+    && /opt/conda/bin/conda config --show-sources
+
+ENV PATH="/opt/conda/bin:${PATH}"
+
+CMD [ "/bin/bash" ]

--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -36,7 +36,7 @@ RUN yum install -q -y deltarpm \
         #----------------------------------------
         # X11 virtual framebuffer; useful for testing GUI apps
         #----------------------------------------
-        #xorg-x11-server-Xvfb \
+        xorg-x11-server-Xvfb \
         #----------------------------------------
         # Other hardware and low-level system libraries
         #----------------------------------------


### PR DESCRIPTION
Dockerfile + CI/CD files to generate images used by Anaconda Inc. to build conda packages for the defaults channel.