### PR TITLE
Fix miniconda debian push condition

### DIFF
--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -43,4 +43,4 @@ jobs:
           file: ./miniconda3/debian/Dockerfile
           tags: continuumio/miniconda3/debian:latest
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-          push: ${{ github.ref == 'ref/head/master' }}
+          push: ${{ github.ref == 'refs/heads/master' }}

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -2,8 +2,6 @@ FROM debian:buster-slim
 
 LABEL maintainer="Anaconda, Inc"
 
-SHELL ["/bin/bash", "-o", "errtrace", "-o", "nounset", "-o", "pipefail", "-o", "errexit", "-c"]
-
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # hadolint ignore=DL3008
@@ -29,6 +27,7 @@ CMD [ "/bin/bash" ]
 # Leave these args here to better use the Docker build cache
 ARG CONDA_VERSION=py38_4.9.2
 
+# hadolint ignore=DL4006
 RUN set -x && \
     UNAME_M="$(uname -m)" && \
     if [ "${UNAME_M}" = "x86_64" ]; then \


### PR DESCRIPTION
Also removes the unintentional shell overwrite from miniconda debian image, which was not published yet.