### PR TITLE
Explicitly add openssh-client

### DIFF
--- a/anaconda3/debian/Dockerfile
+++ b/anaconda3/debian/Dockerfile
@@ -11,10 +11,11 @@ RUN set -x && \
         ca-certificates \
         git \
         libglib2.0-0 \
-        libxext6 \
         libsm6 \
+        libxext6 \
         libxrender1 \
         mercurial \
+        openssh-client \
         subversion \
         wget \
     && apt-get clean \

--- a/anaconda3/debian/Dockerfile
+++ b/anaconda3/debian/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH
 
-# hadolint ignore=DL3008,DL4006
+# hadolint ignore=DL3008
 RUN set -x && \
     apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
@@ -35,9 +35,10 @@ RUN set -x && \
         SHA256SUM="097064807a9adae3f91fc4c5852cd90df2b77fc96505929bb25bf558f1eef76f"; \
     fi && \
     wget "${ANACONDA_URL}" -O anaconda.sh -q && \
-    echo "${SHA256SUM} anaconda.sh" | sha256sum --check --status && \
+    echo "${SHA256SUM} anaconda.sh" > shasum && \
+    sha256sum --check --status shasum && \
     /bin/bash anaconda.sh -b -p /opt/conda && \
-    rm anaconda.sh && \
+    rm anaconda.sh shasum && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -28,7 +28,6 @@ CMD [ "/bin/bash" ]
 # Leave these args here to better use the Docker build cache
 ARG CONDA_VERSION=py38_4.9.2
 
-# hadolint ignore=DL4006
 RUN set -x && \
     UNAME_M="$(uname -m)" && \
     if [ "${UNAME_M}" = "x86_64" ]; then \
@@ -45,10 +44,11 @@ RUN set -x && \
         SHA256SUM="2b111dab4b72a34c969188aa7a91eca927a034b14a87f725fa8d295955364e71"; \
     fi && \
     wget "${MINICONDA_URL}" -O miniconda.sh -q && \
-    if [ "${CONDA_VERSION}" != "latest" ]; then echo "${SHA256SUM} miniconda.sh" | sha256sum --check --status; fi && \
+    echo "${SHA256SUM} miniconda.sh" > shasum && \
+    if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh && \
+    rm miniconda.sh shasum && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -q && \
         libxext6 \
         libxrender1 \
         mercurial \
+        openssh-client \
         subversion \
         wget \
     && apt-get clean \


### PR DESCRIPTION
The addition of the --no-install-recommends switch to apt-get removed some
implicitly added packages.

Explicitly re-adding ssh as it is a common requirement, when using the
docker image on CI systems.

Also do shasum checking without pipe to not mask errors.

closes: https://github.com/ContinuumIO/docker-images/issues/218