### PR TITLE
Add tagging support for miniconda3 debian image

### DIFF
--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -1,6 +1,8 @@
 name: Build Miniconda3 Debian Image
 on:
   push:
+    tags:
+      - 'miniconda3-v*.*.*'
     paths:
       - 'miniconda3/debian/Dockerfile'
       - '.github/workflows/miniconda_debian_ci.yml'
@@ -18,7 +20,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -35,12 +37,22 @@ jobs:
           version: latest
           driver-opts: network=host
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: continuumio/miniconda3
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=match,pattern=miniconda3-v(.*),group=1
+
       - name: build miniconda3/debian
         uses: docker/build-push-action@v2
         with:
           context: ./miniconda3/debian
           builder: ${{ steps.buildx.outputs.name }}
           file: ./miniconda3/debian/Dockerfile
-          tags: continuumio/miniconda3:latest
+          tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-          push: ${{ github.ref == 'refs/heads/master' }}
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}


### PR DESCRIPTION
This should result into:

| Event           | Ref                           | Docker Tags                         |
|-----------------|-------------------------------|-------------------------------------|
| `pull_request`  | `refs/pull/2/merge`           | `pr-2`                              |
| `push`          | `refs/heads/master`           | `master`                            |
| `push tag`      | `refs/tags/miniconda3-v1.2.3`            | `v1.2.3`, `latest`                  |
| `push tag`      | `refs/tags/miniconda3-v2.0.8-beta.67`    | `v2.0.8-beta.67`, `latest`          |

So *latest* points to latest tagged image, *master* points to latest upload from push to master. 

While git tags propagate to docker image tags, they don't yet propagate into the image by influencing which miniconda3 version is installed, as sha256 sums are hard coded right now.

The update process is therefore:
* PR updating the Dockerfile to latest miniconda3 release including specifying sha256sums.
* Merging the PR to master and waiting until an updated image tagged *master* is available from dockerhub.
* Testing the master image and tagging the master branch with *miniconda3-vX.Y.Z*.
* miniconda3:X.Y.Z and miniconda3:latest get built and pushed to dockerhub.

ref: https://github.com/docker/metadata-action