### PR TITLE
Add procps providing /bin/ps

### DIFF
--- a/anaconda3/debian/Dockerfile
+++ b/anaconda3/debian/Dockerfile
@@ -16,6 +16,7 @@ RUN set -x && \
         libxrender1 \
         mercurial \
         openssh-client \
+        procps \
         subversion \
         wget \
     && apt-get clean \

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -q && \
         libxrender1 \
         mercurial \
         openssh-client \
+        procps \
         subversion \
         wget \
     && apt-get clean \


### PR DESCRIPTION
This removes the warning during build:

"miniconda.sh: 27: miniconda.sh: ps: not found"