### PR TITLE
Secure github actions via immutable sha1s instead of version tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ana_pkg_build_cicd.yml
+++ b/.github/workflows/ana_pkg_build_cicd.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         if: github.ref == 'refs/heads/master'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -21,13 +21,13 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@e673438944759779e411a0f7ceef3ba437dccfa0
         with:
           version: latest
           driver-opts: network=host
 
       - name: build-push pkg-builder-x86_64
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./anaconda-pkg-build/linux
           builder: ${{ steps.buildx.outputs.name }}
@@ -41,7 +41,7 @@ jobs:
           push: github.ref == 'refs/heads/master'
 
       - name: build-push pkg-builder-ppc64le
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./anaconda-pkg-build/linux
           builder: ${{ steps.buildx.outputs.name }}
@@ -55,7 +55,7 @@ jobs:
           push: github.ref == 'refs/heads/master'
 
       - name: build-push pkg-builder-aarch64
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./anaconda-pkg-build/linux
           builder: ${{ steps.buildx.outputs.name }}
@@ -69,7 +69,7 @@ jobs:
           push: github.ref == 'refs/heads/master'
 
       - name: build-push pkg-builder-s390x
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./anaconda-pkg-build/linux
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/anaconda_alpine_ci.yml
+++ b/.github/workflows/anaconda_alpine_ci.yml
@@ -14,17 +14,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@e673438944759779e411a0f7ceef3ba437dccfa0
         with:
           version: latest
           driver-opts: network=host
 
       - name: build anaconda3/alpine
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./anaconda3/alpine
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/anaconda_debian_ci.yml
+++ b/.github/workflows/anaconda_debian_ci.yml
@@ -14,29 +14,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         if: github.ref == 'refs/heads/master'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@c308fdd69d26ed66f4506ebd74b180abe5362145
         with:
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@e673438944759779e411a0f7ceef3ba437dccfa0
         with:
           version: latest
           driver-opts: network=host
 
       - name: Build anaconda3/debian
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./anaconda3/debian
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/conda_ci_cicd.yml
+++ b/.github/workflows/conda_ci_cicd.yml
@@ -38,7 +38,7 @@ jobs:
           file: ./conda_ci/conda-ci-linux-64-python3/Dockerfile
           build-args: PYTHON_VERSION=3.9
           tags: continuumio/conda-ci-linux-64-python3.9:latest
-          push: github.ref == 'refs/heads/master'
+          push: ${{ github.ref == 'refs/heads/master' }}
 
       - name: build-push conda-ci-linux-64-python3.8
         uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
@@ -48,7 +48,7 @@ jobs:
           file: ./conda_ci/conda-ci-linux-64-python3/Dockerfile
           build-args: PYTHON_VERSION=3.8
           tags: continuumio/conda-ci-linux-64-python3.8:latest
-          push: github.ref == 'refs/heads/master'
+          push: ${{ github.ref == 'refs/heads/master' }}
 
       - name: build-push conda-ci-linux-64-python3.7
         uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
@@ -58,4 +58,4 @@ jobs:
           file: ./conda_ci/conda-ci-linux-64-python3/Dockerfile
           build-args: PYTHON_VERSION=3.7
           tags: continuumio/conda-ci-linux-64-python3.7:latest
-          push: github.ref == 'refs/heads/master'
+          push: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/conda_ci_cicd.yml
+++ b/.github/workflows/conda_ci_cicd.yml
@@ -16,22 +16,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         if: github.ref == 'refs/heads/master'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@e673438944759779e411a0f7ceef3ba437dccfa0
         with:
           version: latest
           driver-opts: network=host
 
       - name: build-push conda-ci-linux-64-python3.9
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./conda_ci/conda-ci-linux-64-python3
           builder: ${{ steps.buildx.outputs.name }}
@@ -41,7 +41,7 @@ jobs:
           push: github.ref == 'refs/heads/master'
 
       - name: build-push conda-ci-linux-64-python3.8
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./conda_ci/conda-ci-linux-64-python3
           builder: ${{ steps.buildx.outputs.name }}
@@ -51,7 +51,7 @@ jobs:
           push: github.ref == 'refs/heads/master'
 
       - name: build-push conda-ci-linux-64-python3.7
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./conda_ci/conda-ci-linux-64-python3
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
       - name: Lint
         run: |
           echo "::add-matcher::.github/hadolint-matcher.json"

--- a/.github/workflows/miniconda_alpine_ci.yml
+++ b/.github/workflows/miniconda_alpine_ci.yml
@@ -14,17 +14,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@e673438944759779e411a0f7ceef3ba437dccfa0
         with:
           version: latest
           driver-opts: network=host
 
       - name: build miniconda3/alpine
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./miniconda3/alpine
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -16,30 +16,30 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@c308fdd69d26ed66f4506ebd74b180abe5362145
         with:
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@e673438944759779e411a0f7ceef3ba437dccfa0
         with:
           version: latest
           driver-opts: network=host
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@f6efe56d565add159ad605568120f5b22712a870
         with:
           images: continuumio/miniconda3
           tags: |
@@ -48,7 +48,7 @@ jobs:
             type=match,pattern=miniconda3-v(.*),group=1
 
       - name: build miniconda3/debian
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@0987321e128873c0caa3bed11ad3b83f22b846ed
         with:
           context: ./miniconda3/debian
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
Github action versions are derived from git tags as actions are just cloned as repos and used during flows.

But tags can be deleted and republished with malicious code, whereas a commit at a specific hash is immutable.

Dependabot helps to keep the non-human-readable sha1 pinned versions up-to-date by providing update PRs with changelogs.