### PR TITLE
Update Miniconda3 alpine to 4.10.3

### DIFF
--- a/.github/workflows/miniconda_alpine_ci.yml
+++ b/.github/workflows/miniconda_alpine_ci.yml
@@ -1,6 +1,8 @@
 name: Build Miniconda3 Alpine Image
 on:
   push:
+    tags:
+      - 'miniconda3-v*.*.*-alpine'
     paths:
       - 'miniconda3/alpine/Dockerfile'
       - '.github/workflows/miniconda_alpine_ci.yml'
@@ -16,12 +18,31 @@ jobs:
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
+      - name: Login to DockerHub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
         with:
           version: latest
           driver-opts: network=host
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@8b842e721d38d18bea23b57f4c040e53331f4ca2
+        with:
+          images: continuumio/miniconda3
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=match,pattern=miniconda3-v(.*)-alpine,group=1
+          flavor: |
+            suffix=alpine
 
       - name: build miniconda3/alpine
         uses: docker/build-push-action@1bc1040caef9e604eb543693ba89b5bf4fc80935
@@ -30,4 +51,4 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: ./miniconda3/alpine/Dockerfile
           tags: continuumio/miniconda3/alpine:latest
-          push: false
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}

--- a/miniconda3/alpine/Dockerfile
+++ b/miniconda3/alpine/Dockerfile
@@ -52,22 +52,23 @@ LABEL maintainer="Anaconda, Inc"
 
 ENV PATH /opt/conda/bin:$PATH
 
-ENV ENV /root/.shinit   # set path to `ash` equivalent of ~/.bashrc
-CMD [ "/bin/sh" ]
-
 # Leave these args here to better use the Docker build cache
 ARG CONDA_VERSION=py39_4.10.3
 ARG SHA256SUM=1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh && \
+# hadolint ignore=DL3018
+RUN apk add -q --no-cache bash psmisc && \
+    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh && \
     echo "${SHA256SUM}  miniconda.sh" > miniconda.sha256 && \
     if ! sha256sum -cs miniconda.sha256; then exit 1; fi && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/conda && \
     rm miniconda.sh miniconda.sha256 && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.shinit && \
-    echo "conda activate base" >> ~/.shinit && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
     /opt/conda/bin/conda clean -afy
+
+CMD ["/bin/bash"]

--- a/miniconda3/alpine/Dockerfile
+++ b/miniconda3/alpine/Dockerfile
@@ -1,7 +1,4 @@
-FROM alpine:3.12.1 as alpine-glibc
-
-#  $ docker build . -t continuumio/miniconda3:4.9.2-alpine
-#  $ docker push continuumio/miniconda3:4.9.2-alpine
+FROM alpine:3.14.0 as alpine-glibc
 
 LABEL maintainer="Vlad Frolov"
 LABEL src=https://github.com/frol/docker-alpine-glibc
@@ -11,7 +8,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # hadolint ignore=DL3018
 RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
-    ALPINE_GLIBC_PACKAGE_VERSION="2.32-r0" && \
+    ALPINE_GLIBC_PACKAGE_VERSION="2.33-r0" && \
     ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
     ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
     ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
@@ -64,7 +61,7 @@ ARG SHA256SUM=1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f
 
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh && \
     echo "${SHA256SUM}  miniconda.sh" > miniconda.sha256 && \
-    if ! sha256sum --check --status miniconda.sha256; then exit 1; fi && \
+    if ! sha256sum -cs miniconda.sha256; then exit 1; fi && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/conda && \
     rm miniconda.sh miniconda.sha256 && \

--- a/miniconda3/alpine/Dockerfile
+++ b/miniconda3/alpine/Dockerfile
@@ -59,15 +59,15 @@ ENV ENV /root/.shinit   # set path to `ash` equivalent of ~/.bashrc
 CMD [ "/bin/sh" ]
 
 # Leave these args here to better use the Docker build cache
-ARG CONDA_VERSION=py38_4.9.2
-ARG CONDA_MD5=122c8c9beb51e124ab32a0fa6426c656
+ARG CONDA_VERSION=py39_4.10.3
+ARG SHA256SUM=1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f
 
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh && \
-    echo "${CONDA_MD5}  miniconda.sh" > miniconda.md5 && \
-    if ! md5sum -s -c miniconda.md5; then exit 1; fi && \
+    echo "${SHA256SUM}  miniconda.sh" > miniconda.sha256 && \
+    if ! sha256sum --check --status miniconda.sha256; then exit 1; fi && \
     mkdir -p /opt && \
     sh miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh miniconda.md5 && \
+    rm miniconda.sh miniconda.sha256 && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.shinit && \
     echo "conda activate base" >> ~/.shinit && \


### PR DESCRIPTION
Also update:
* The Alpine base image to 3.14.0 and glibc to 2.33-r0
* The Github action to push the image
* Switch to bash as ash is not fully supported by conda and add psmisc