### PR TITLE
Update docker jupyter example command and Python version in READMEs

### DIFF
--- a/anaconda3/README.md
+++ b/anaconda3/README.md
@@ -1,6 +1,6 @@
 # docker-anaconda
 
-Docker container with a bootstrapped installation of [Anaconda](http://continuum.io/downloads) (based on Python 3.X) that is ready to use.
+Docker container with a bootstrapped installation of [Anaconda](https://www.anaconda.com/products/individual#Downloads) (based on Python 3.X) that is ready to use.
 
 The Anaconda distribution is installed into the `/opt/conda` folder and ensures that the default user has the `conda` command in their path.
 

--- a/anaconda3/README.md
+++ b/anaconda3/README.md
@@ -1,6 +1,6 @@
 # docker-anaconda
 
-Docker container with a bootstrapped installation of [Anaconda](http://continuum.io/downloads) (based on Python 3.7) that is ready to use.
+Docker container with a bootstrapped installation of [Anaconda](http://continuum.io/downloads) (based on Python 3.X) that is ready to use.
 
 The Anaconda distribution is installed into the `/opt/conda` folder and ensures that the default user has the `conda` command in their path.
 
@@ -16,6 +16,11 @@ You can download and run this image using the following commands:
 
 Alternatively, you can start a Jupyter Notebook server and interact with Anaconda via your browser:
 
-    docker run -i -t -p 8888:8888 continuumio/anaconda3 conda "install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='0.0.0.0' --port=8888 --no-browser"
+    docker run -i -t -p 8888:8888 continuumio/anaconda3 /bin/bash -c "\
+        conda install jupyter -y --quiet && \
+        mkdir -p /opt/notebooks && \
+        jupyter notebook \
+        --notebook-dir=/opt/notebooks --ip='*' --port=8888 \
+        --no-browser --allow-root"
 
 You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker.

--- a/miniconda3/README.md
+++ b/miniconda3/README.md
@@ -1,6 +1,6 @@
 # docker-miniconda
 
-Docker container with a bootstrapped installation of [Miniconda](http://conda.pydata.org/miniconda.html) (based on Python 3.8) that is ready to use.
+Docker container with a bootstrapped installation of [Miniconda](http://conda.pydata.org/miniconda.html) (based on Python 3.X) that is ready to use.
 
 The Miniconda distribution is installed into the `/opt/conda` folder and ensures that the default user has the `conda` command in their path.
 
@@ -16,6 +16,11 @@ You can download and run this image using the following commands:
 
 Alternatively, you can start a Jupyter Notebook server and interact with Miniconda via your browser:
 
-    docker run -i -t -p 8888:8888 continuumio/miniconda3 conda "install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='0.0.0.0' --port=8888 --no-browser"
+    docker run -i -t -p 8888:8888 continuumio/miniconda3 /bin/bash -c "\
+        conda install jupyter -y --quiet && \
+        mkdir -p /opt/notebooks && \
+        jupyter notebook \
+        --notebook-dir=/opt/notebooks --ip='*' --port=8888 \
+        --no-browser --allow-root"
 
 You can then view the Jupyter Notebook by opening `http://localhost:8888` in your browser, or `http://<DOCKER-MACHINE-IP>:8888` if you are using a Docker.

--- a/miniconda3/README.md
+++ b/miniconda3/README.md
@@ -1,6 +1,6 @@
 # docker-miniconda
 
-Docker container with a bootstrapped installation of [Miniconda](http://conda.pydata.org/miniconda.html) (based on Python 3.X) that is ready to use.
+Docker container with a bootstrapped installation of [Miniconda](https://docs.conda.io/en/latest/miniconda.html) (based on Python 3.X) that is ready to use.
 
 The Miniconda distribution is installed into the `/opt/conda` folder and ensures that the default user has the `conda` command in their path.
 


### PR DESCRIPTION
* Adding -p helps of container restarts
* --allow-root is required since a while, as there currently is no user setup in the container
* Referencing Python 3.X to make the README more generic for further updates.
* Updating installer download page URLs