### PR TITLE
Upgrade to bullseye for Debian based containers

### DIFF
--- a/anaconda3/debian/Dockerfile
+++ b/anaconda3/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 LABEL maintainer="Anaconda, Inc"
 


### PR DESCRIPTION
Debian 11 bullseye was released on 2021-08-14:

https://www.debian.org/News/2021/20210814

Merging this to master results in a new container upload with tag `master`, which allows testing the created image before the next version tagged release.