### PR TITLE
support for ECR

### DIFF
--- a/.github/workflows/miniconda_debian_ci.yml
+++ b/.github/workflows/miniconda_debian_ci.yml
@@ -25,6 +25,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
         with:
@@ -41,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@3a3bb3a81753dc99f090d24ee7e5343838b73a96
         with:
-          images: continuumio/miniconda3
+          images: continuumio/miniconda3,public.ecr.aws/y0o4y9o3/miniconda3
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
added:

- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for  (public.ecr.aws/y0o4y9o3)
- these repos:
```
anaconda2
anaconda
conda-ci-linux-64-python3.8
concourse-rsync-resource
anaconda3
conda-ci-linux-64-python3.7
miniconda2
miniconda
conda-ci-linux-64-python2.7
miniconda3
```
