### PR TITLE
Publish concourse-rsync-resource via github actions

### DIFF
--- a/.github/workflows/concourse_rsync_resource.yml
+++ b/.github/workflows/concourse_rsync_resource.yml
@@ -1,0 +1,67 @@
+name: Build and publish the concourse-rsync-resource image
+on:
+  push:
+    tags:
+      - 'crr-*'
+    paths:
+      - 'concourse-rsync-resource/Dockerfile'
+      - '.github/workflows/concourse_rsync_resource.yml'
+  pull_request:
+    paths:
+      - 'concourse-rsync-resource/Dockerfile'
+      - '.github/workflows/concourse_rsync_resource.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          submodules: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        if: github.ref == 'refs/heads/master'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to Public ECR
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        if: github.ref == 'refs/heads/master'
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+        with:
+          version: latest
+          driver-opts: network=host
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@3a3bb3a81753dc99f090d24ee7e5343838b73a96
+        with:
+          images: |
+            conda/concourse-rsync-resource
+            public.ecr.aws/y0o4y9o3/concourse-rsync-resource
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=match,pattern=crr-(.*),group=1
+
+      - name: build-push
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          context: ./concourse-rsync-resource
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./concourse-rsync-resource/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "concourse-rsync-resource"]
+	path = concourse-rsync-resource
+	url = ../../AnacondaRecipes/concourse-rsync-resource.git
+	branch = master


### PR DESCRIPTION
Use the repo to publish the concourse-rsync-resource via github actions, as the logic + secret is in common with the other workflows.