### PR TITLE
Add entrypoint for docker image

### DIFF
--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -117,4 +117,4 @@ RUN rm -fv /opt/conda/.condarc \
 
 ENV PATH="/opt/conda/bin:${PATH}"
 
-CMD [ "/bin/bash" ]
+ENTRYPOINT [ "/opt/conda/bin/conda-build", "--suppress-variables", "--error-overlinking", "--error-overdepending" ]

--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -117,4 +117,6 @@ RUN rm -fv /opt/conda/.condarc \
 
 ENV PATH="/opt/conda/bin:${PATH}"
 
-ENTRYPOINT [ "/opt/conda/bin/conda-build", "--suppress-variables", "--error-overlinking", "--error-overdepending" ]
+COPY entrypoint.sh /entrypoint.sh
+
+CMD ["/entrypoint.sh"]

--- a/anaconda-pkg-build/linux/entrypoint.sh
+++ b/anaconda-pkg-build/linux/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errtrace -o nounset -o pipefail -o errexit -x
+
+env | sort
+
+DEFAULT_BUILD_ARGS=(--suppress-variables --error-overlinking --error-overdepending)
+declare -a BUILD_ARGS=()
+for arg do
+    shift
+    if [[ "${arg}" == -build-args=* ]]; then
+        IFS=',' read -r -a BUILD_ARGS <<< "${arg//-build-args=}"
+        continue
+    fi
+    set -- "$@" "${arg}"
+done
+
+if [ "${#BUILD_ARGS[@]}" -eq 0 ]; then
+    BUILD_ARGS="${DEFAULT_BUILD_ARGS[@]}"
+fi
+
+conda config --system --add default_channels https://repo.anaconda.com/pkgs/main
+conda config --system --add default_channels https://repo.anaconda.com/pkgs/r
+
+# read + set -channels=*
+# ...
+# conda config --system --add channels c3i_test2
+
+conda info -a
+
+conda build "${BUILD_ARGS[@]}" /feedstock -m /feedstock/.abs/conda_build_config.yaml --output-folder /upload
+
+chmod -R 777 /upload


### PR DESCRIPTION
This is so that users can run our docker images like an executable to build a particular feedstock.

```
docker run -v $PATH_TO_FEEDSTOCK:/feedstock -it $IMAGE_HASH /feedstock
```

Signed-off-by: Connor Martin <connormartin7@gmail.com>