### PR TITLE
Add Concourse specific build image.

### DIFF
--- a/.github/workflows/anaconda_pkg_build.yml
+++ b/.github/workflows/anaconda_pkg_build.yml
@@ -69,3 +69,28 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}
+
+      - name: Docker meta for Concourse
+        id: concourse-meta
+        uses: docker/metadata-action@3a3bb3a81753dc99f090d24ee7e5343838b73a96
+        with:
+          images: |
+            continuumio/concourse-pkg-build
+            public.ecr.aws/y0o4y9o3/concourse-pkg-build
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=match,pattern=pkg-build-(.*),group=1
+
+      - name: build-push pkg-builder-concourse
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          context: ./anaconda-pkg-build/linux
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./anaconda-pkg-build/linux/Dockerfile
+          platform: linux/amd64
+          build-args: |
+            BASEVERSION=7
+          tags: ${{ steps.concourse-meta.outputs.tags }}
+          labels: ${{ steps.concourse-meta.outputs.labels }}
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/anaconda_pkg_build.yml
+++ b/.github/workflows/anaconda_pkg_build.yml
@@ -88,7 +88,7 @@ jobs:
           context: ./anaconda-pkg-build/linux
           builder: ${{ steps.buildx.outputs.name }}
           file: ./anaconda-pkg-build/linux/Dockerfile
-          platform: linux/amd64
+          platforms: linux/amd64
           build-args: |
             BASEVERSION=7
           tags: ${{ steps.concourse-meta.outputs.tags }}

--- a/.github/workflows/anaconda_pkg_build.yml
+++ b/.github/workflows/anaconda_pkg_build.yml
@@ -81,6 +81,8 @@ jobs:
             type=ref,event=branch,suffix=-amd64
             type=ref,event=pr,suffix=-amd64
             type=match,pattern=pkg-build-(.*),group=1,suffix=-amd64
+          flavor: |
+            latest=false
 
       - name: build-push pkg-builder-concourse
         uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229

--- a/.github/workflows/anaconda_pkg_build.yml
+++ b/.github/workflows/anaconda_pkg_build.yml
@@ -75,12 +75,12 @@ jobs:
         uses: docker/metadata-action@3a3bb3a81753dc99f090d24ee7e5343838b73a96
         with:
           images: |
-            continuumio/concourse-pkg-build
-            public.ecr.aws/y0o4y9o3/concourse-pkg-build
+            continuumio/anaconda-pkg-build
+            public.ecr.aws/y0o4y9o3/anaconda-pkg-build
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=match,pattern=pkg-build-(.*),group=1
+            type=ref,event=branch,suffix=-amd64
+            type=ref,event=pr,suffix=-amd64
+            type=match,pattern=pkg-build-(.*),group=1,suffix=-amd64
 
       - name: build-push pkg-builder-concourse
         uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229


### PR DESCRIPTION
Currently, our version of Concourse is struggling with the manifest list v2. 😞 

To alleviate that, we can try building an image from the same Dockerfile as the `anaconda-pkg-build` only for **linux/amd64**. The meta and steps are similar but it has a new name: `concourse-pkg-build`. This should put a sole manifest & image into ECR, similar to `concourse-rsync-resource`

I am open to thoughts on alternatives or other options to get a single image manifest in ECR. I was not sure if we could tag one platform specifically, i.e.,:

> public.ecr.aws/<...>/anaconda-pkg-build:linux-64
