### PR TITLE
Add tar to the build image.

### DIFF
--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -73,6 +73,7 @@ RUN yum install -q -y deltarpm \
         openssh-clients \
         psmisc \
         rsync \
+        tar \
         util-linux \
         #wget \
         which \


### PR DESCRIPTION
`tar` is currently available on all linux images aside from **linux-aarch64** (amazonlinux). So, make it explicit include `/usr/bin/tar`.

As far as I know, we currently do not provide `tar` in **defaults**. That would be the other option.

Suggesting this as it is causing [git-feedstock](https://github.com/AnacondaRecipes/git-feedstock/pull/7)'s build to fail.

