### PR TITLE
Unpin Miniconda alpine release updates

### DIFF
--- a/miniconda3/alpine/Dockerfile
+++ b/miniconda3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.0 as alpine-glibc
+FROM alpine:3.14 as alpine-glibc
 
 LABEL maintainer="Vlad Frolov"
 LABEL src=https://github.com/frol/docker-alpine-glibc


### PR DESCRIPTION
Allows building and uploading an updated image just by tagging a new release (as it is possible for the other images).

fixes: https://github.com/ContinuumIO/docker-images/issues/261