### PR TITLE
Install libglvnd-opengl to have libOpenGL.so.* available

### DIFF
--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -49,6 +49,10 @@ RUN yum install -q -y deltarpm \
         #mesa-libGL \
         #mesa-libGLU \
         #----------------------------------------
+        # Vendor-neutral OpenGL
+        #----------------------------------------
+        libglvnd-opengl \
+        #----------------------------------------
         # X11 virtual framebuffer; useful for testing GUI apps
         #----------------------------------------
         xorg-x11-server-Xvfb \


### PR DESCRIPTION
Let me know, if you'd prefer a different solution, but we do have packages that use OpenGL (e.g. VTK) and need libOpenGL.so.* around during testing.