### PR TITLE
Bump miniconda3 alpine image from `3.14` to `3.15.4`

### DIFF
--- a/miniconda3/alpine/Dockerfile
+++ b/miniconda3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14 as alpine-glibc
+FROM alpine:3.15.4 as alpine-glibc
 
 LABEL maintainer="Vlad Frolov"
 LABEL src=https://github.com/frol/docker-alpine-glibc


### PR DESCRIPTION
I'm a Dockerfile noob so please be gentle :stuck_out_tongue_closed_eyes: 

I don't see any breaking changes in 3.15.0 from release notes: https://alpinelinux.org/posts/Alpine-3.15.0-released.html

The other minor updates (https://alpinelinux.org/releases/) includes fixes for various CVEs so risk of breakage should be low.