### PR TITLE
Update cached gcc version to 11.2.0 to be in line with aggregate/cbc.yaml

### DIFF
--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -2,18 +2,15 @@
 # packages released on the "defaults" (repo.anaconda.com) channels.
 
 ARG BASEVERSION=7
+ARG GCC_VER=11.2.0
 
 FROM centos:${BASEVERSION} AS base-amd64
-ARG GCC_VER=7.5
 
 FROM centos:${BASEVERSION} AS base-ppc64le
-ARG GCC_VER=7.3
 
 FROM amazonlinux:2 AS base-arm64
-ARG GCC_VER=10.2
 
 FROM clefos:${BASEVERSION} AS base-s390x
-ARG GCC_VER=7.5
 
 # hadolint ignore=DL3006
 FROM base-$TARGETARCH


### PR DESCRIPTION
The `GCC_VER` arg only has influence on what is cached by the container to achieve faster builds. What is really used during a build is fully defined by the feedstock/cbc.yaml.

See also: https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L52