### PR TITLE
Delete index-cache at the end of container creation

### DIFF
--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -120,7 +120,8 @@ RUN MC_ARCH="$(uname -m)" \
     # Note, too, that this MUST come _after_ the `conda clean --all` above,
     # or the compilers will be dumped from the package cache.
     && /opt/conda/bin/conda install --download-only --quiet --yes \
-        "gcc_linux-$subdir=${GCC_VER}" "gxx_linux-$subdir=${GCC_VER}"
+        "gcc_linux-$subdir=${GCC_VER}" "gxx_linux-$subdir=${GCC_VER}" \
+    && /opt/conda/bin/conda clean --index-cache --yes
 
 ENV PATH="/opt/conda/bin:${PATH}"
 


### PR DESCRIPTION
This hopefully is the last attempt to enable libmamba as solver:
* It was initially enabled via https://github.com/ContinuumIO/docker-images/pull/350
* Then setting the solver was done after clean to avoid incompatible cache meta data https://github.com/ContinuumIO/docker-images/pull/355 and https://github.com/ContinuumIO/docker-images/pull/356

The container created from current master branch still fails on s390x:

```docker run -ti --rm --platform linux/s390x continuumio/anaconda-pkg-build:master /bin/bash -c "conda install numpy"``` with `RuntimeError: Could not read JSON repodata file (/opt/conda/pkgs/cache/8943ae43.json) parse error line 1`

But is successful with ```docker run -ti --rm --platform linux/s390x continuumio/anaconda-pkg-build:master /bin/bash -c "conda clean --index-cache --yes && conda install numpy --yes"``` ... Thus adding the index-cache clean command at the end of container creation.
