### PR TITLE
add git to linux dockerfile

### DIFF
--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -69,6 +69,7 @@ RUN yum install -q -y deltarpm \
         # assume the build container provides these tools.
         #----------------------------------------
         curl \
+        git \
         file \
         net-tools \
         openssh-clients \


### PR DESCRIPTION
scipy builds are failing because git is not installed in the build container.