### PR TITLE
Disable latest tag for lts container

### DIFF
--- a/.github/workflows/anaconda_pkg_build_lts_linux.yml
+++ b/.github/workflows/anaconda_pkg_build_lts_linux.yml
@@ -58,6 +58,8 @@ jobs:
             type=ref,event=branch,suffix=-lts
             type=ref,event=pr,suffix=-lts
             type=match,pattern=lts-pkg-build-(.*),group=1,suffix=-lts
+          flavor: |
+            latest=false
 
       - name: build-push pkg-builder
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v4


### PR DESCRIPTION
see also https://github.com/ContinuumIO/docker-images/blob/main/.github/workflows/anaconda_pkg_build_linux.yml#L86