### PR TITLE
Add anaconda-pkg-base image

### DIFF
--- a/anaconda-pkg-base/linux/README.md
+++ b/anaconda-pkg-base/linux/README.md
@@ -1,0 +1,25 @@
+# Base `Dockerfile`s for testing on linux-{amd64, aarch64, ppc64le, s390x}
+
+Based on [anaconda-pkg-build](https://github.com/ContinuumIO/docker-images/blob/master/anaconda-pkg-build/linux/Dockerfile), but without miniconda3 pre-installed. This allows testing of miniconda3/anaconda3/other installers including testing conda-build.
+
+
+## Build examples
+
+```
+docker build -f ubuntu.Dockerfile -t anaconda-base/ubuntu2004 .
+docker build -f defaults.Dockerfile -t anaconda-base/defaults .
+```
+
+## Run examples
+
+```
+docker run -it --rm anaconda-base/ubuntu2004
+docker run -it --rm anaconda-base/defaults
+```
+
+The images can also be used with Dockers platform emulation via qemu:
+
+* Required once to enable cross-platform emulation: `docker run --privileged --rm tonistiigi/binfmt --install all`
+* Building/running with the `--platform` arg:
+    * `docker build --platform linux/s390x -f ubuntu.Dockerfile -t anaconda-base/ubuntu2004`
+    * `docker run --platform linux/s390x -it --rm anaconda-base/ubuntu2004`

--- a/anaconda-pkg-base/linux/defaults.Dockerfile
+++ b/anaconda-pkg-base/linux/defaults.Dockerfile
@@ -1,0 +1,85 @@
+ARG BASEVERSION=7
+
+FROM centos:${BASEVERSION} AS base-amd64
+
+FROM centos:${BASEVERSION} AS base-ppc64le
+
+FROM amazonlinux:2 AS base-arm64
+
+FROM clefos:${BASEVERSION} AS base-s390x
+
+# hadolint ignore=DL3006
+FROM base-$TARGETARCH
+
+# hadolint ignore=DL3031,DL3033
+RUN yum install -q -y deltarpm \
+    # Hack to force locale generation, if needed
+    && yum update -q -y glibc-common \
+    && yum install -q -y \
+        #----------------------------------------
+        # X11-related libraries needed for various CDTs
+        #----------------------------------------
+        libX11 \
+        libXau \
+        libxcb \
+        libXcomposite \
+        libXcursor \
+        libXdamage \
+        libXdmcp \
+        libXext \
+        libXfixes \
+        libXi \
+        libXinerama \
+        libXrandr \
+        libXrender \
+        libXScrnSaver \
+        libXt \
+        libXtst \
+        #----------------------------------------
+        # MESA 3D graphics library
+        #----------------------------------------
+        #mesa-libEGL \
+        #mesa-libGL \
+        #mesa-libGLU \
+        #----------------------------------------
+        # Vendor-neutral OpenGL
+        #----------------------------------------
+        libglvnd-opengl \
+        #----------------------------------------
+        # X11 virtual framebuffer; useful for testing GUI apps
+        #----------------------------------------
+        xorg-x11-server-Xvfb \
+        #----------------------------------------
+        # Other hardware and low-level system libraries
+        #----------------------------------------
+        #alsa-lib \
+        #libselinux \
+        #pam \
+        #pciutils-libs \
+        #----------------------------------------
+        # Low-level and basic system utilities.
+        #
+        # NOTE: previous versions of this image included tools like `patch`
+        # and `make`; these days, we prefer package recipes list the
+        # equivalent conda packages as build dependencies, rather than
+        # assume the build container provides these tools.
+        #----------------------------------------
+        curl \
+        file \
+        net-tools \
+        openssh-clients \
+        procps-ng \
+        psmisc \
+        rsync \
+        tar \
+        util-linux \
+        #wget \
+        which \
+    && yum clean all
+
+# Set the locale
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+CMD [ "/bin/bash" ]

--- a/anaconda-pkg-base/linux/ubuntu.Dockerfile
+++ b/anaconda-pkg-base/linux/ubuntu.Dockerfile
@@ -1,0 +1,69 @@
+ARG BASEVERSION=20.04
+
+FROM ubuntu:${BASEVERSION}
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+    # # Hack to force locale generation, if needed
+    && apt-get install -q -y --no-install-recommends locales locales-all \
+    && apt-get install -q -y --no-install-recommends \
+        #----------------------------------------
+        # X11-related libraries needed for various CDTs
+        #----------------------------------------
+        libx11-6 \
+        libxau6 \
+        libxcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxdmcp6 \
+        libxext6 \
+        libxfixes3 \
+        libxi6 \
+        libxinerama1 \
+        libxrandr2 \
+        libxrender1 \
+        libxss1 \
+        libxt6 \
+        libxtst6 \
+        #----------------------------------------
+        # MESA 3D graphics library
+        #----------------------------------------
+        #mesa-libEGL \
+        #mesa-libGL \
+        #mesa-libGLU \
+        #----------------------------------------
+        # X11 virtual framebuffer; useful for testing GUI apps
+        #----------------------------------------
+        xvfb \
+        #----------------------------------------
+        # Other hardware and low-level system libraries
+        #----------------------------------------
+        #alsa-lib \
+        #libselinux \
+        #pam \
+        #pciutils-libs \
+        #----------------------------------------
+        # Low-level and basic system utilities.
+        #
+        # NOTE: previous versions of this image included tools like `patch`
+        # and `make`; these days, we prefer package recipes list the
+        # equivalent conda packages as build dependencies, rather than
+        # assume the build container provides these tools.
+        #----------------------------------------
+        curl \
+        file \
+        net-tools \
+        openssh-client \
+        psmisc \
+        rsync \
+        util-linux \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the locale
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+CMD [ "/usr/bin/bash" ]


### PR DESCRIPTION
Identiacally to the anaconda-pkg-build image, but without miniconda3 pre-installed. This allows testing of miniconda3/anaconda3/other installers including testing conda-build.

This is based on the previous s390x only qa image, we can be found in the [repo history](https://github.com/ContinuumIO/docker-images/tree/912aa2402e807e2faeaf1e778c6be7cd73e70e1f/qa-images/s390x)