### PR TITLE
update miniconda3 Dockerfile for Singularity runtime

### DIFF
--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -51,6 +51,8 @@ RUN set -x && \
     bash miniconda.sh -b -p /opt/conda && \
     rm miniconda.sh shasum && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    mkdir -p /.singularity.d/env/ && \
+    cp -p /opt/conda/etc/profile.d/conda.sh /.singularity.d/env/91-environment.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -53,6 +53,7 @@ RUN set -x && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     mkdir -p /.singularity.d/env/ && \
     cp -p /opt/conda/etc/profile.d/conda.sh /.singularity.d/env/91-environment.sh && \
+    echo "conda activate base" >> /.singularity.d/env/91-environment.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \


### PR DESCRIPTION
This update makes sure that `conda.sh` is also executed when running containers with Singularity.

Two caveats:
- At this stage I have only updated the Dockefile and nothing else. Are other updates required? e.g. docs or unit tests?
- I have also added `conda activate base`, to have a full 1:1 behaviour match with Docker/Podman. However, I am wondering whether his might disrupt any worfklows of users and 3rd party software interfaces to the project - I don't think so, but am open to your feedback.