### PR TITLE
Add Dockerfile for CUDA 11.8.0

### DIFF
--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -52,8 +52,8 @@ jobs:
         uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5
         with:
           images: |
-            continuumio/anaconda-pkg-build-cuda
-            public.ecr.aws/y0o4y9o3/anaconda-pkg-build-cuda
+            continuumio/anaconda-pkg-build
+            public.ecr.aws/y0o4y9o3/anaconda-pkg-build
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -1,4 +1,4 @@
-name: Build and publish Linux package builder images
+name: Build and publish Linux CUDA package builder images
 on:
   push:
     branches:
@@ -6,12 +6,12 @@ on:
     tags:
       - 'pkg-build-*'
     paths:
-      - 'anaconda-pkg-build/linux/Dockerfile'
-      - '.github/workflows/anaconda_pkg_build_linux.yml'
+      - 'anaconda-pkg-build/linux/cuda/Dockerfile'
+      - '.github/workflows/anaconda_pkg_build_linux_cuda.yml'
   pull_request:
     paths:
-      - 'anaconda-pkg-build/linux/Dockerfile'
-      - '.github/workflows/anaconda_pkg_build_linux.yml'
+      - 'anaconda-pkg-build/linux/cuda/Dockerfile'
+      - '.github/workflows/anaconda_pkg_build_linux_cuda.yml'
   workflow_dispatch:
 
 jobs:
@@ -52,8 +52,8 @@ jobs:
         uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5
         with:
           images: |
-            continuumio/anaconda-pkg-build
-            public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+            continuumio/anaconda-pkg-build-cuda
+            public.ecr.aws/y0o4y9o3/anaconda-pkg-build-cuda
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -62,39 +62,12 @@ jobs:
       - name: build-push pkg-builder
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
         with:
-          context: ./anaconda-pkg-build/linux
+          context: ./anaconda-pkg-build/linux/cuda
           builder: ${{ steps.buildx.outputs.name }}
-          file: ./anaconda-pkg-build/linux/Dockerfile
-          platforms: linux/amd64,linux/ppc64le,linux/arm64/v8,linux/s390x
-          build-args: |
-            BASEVERSION=7
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') }}
-
-      - name: Docker meta for Concourse
-        id: concourse-meta
-        uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5
-        with:
-          images: |
-            continuumio/anaconda-pkg-build
-            public.ecr.aws/y0o4y9o3/anaconda-pkg-build
-          tags: |
-            type=ref,event=branch,suffix=-amd64
-            type=ref,event=pr,suffix=-amd64
-            type=match,pattern=pkg-build-(.*),group=1,suffix=-amd64
-          flavor: |
-            latest=false
-
-      - name: build-push pkg-builder-concourse
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
-        with:
-          context: ./anaconda-pkg-build/linux
-          builder: ${{ steps.buildx.outputs.name }}
-          file: ./anaconda-pkg-build/linux/Dockerfile
+          file: ./anaconda-pkg-build/linux/cuda/Dockerfile
           platforms: linux/amd64
           build-args: |
-            BASEVERSION=7
-          tags: ${{ steps.concourse-meta.outputs.tags }}
-          labels: ${{ steps.concourse-meta.outputs.labels }}
+            CUDA_VERSION=11.8
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -55,9 +55,9 @@ jobs:
             continuumio/anaconda-pkg-build
             public.ecr.aws/y0o4y9o3/anaconda-pkg-build
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=match,pattern=pkg-build-(.*),group=1
+            type=ref,event=branch,suffix=-cuda
+            type=ref,event=pr,suffix=-cuda
+            type=match,pattern=pkg-build-(.*),group=1,suffix=-cuda
 
       - name: build-push pkg-builder
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -1,0 +1,100 @@
+name: Build and publish Linux package builder images
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'pkg-build-*'
+    paths:
+      - 'anaconda-pkg-build/linux/Dockerfile'
+      - '.github/workflows/anaconda_pkg_build_linux.yml'
+  pull_request:
+    paths:
+      - 'anaconda-pkg-build/linux/Dockerfile'
+      - '.github/workflows/anaconda_pkg_build_linux.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to Public ECR
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+        with:
+          version: latest
+          driver-opts: network=host
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5
+        with:
+          images: |
+            continuumio/anaconda-pkg-build
+            public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=match,pattern=pkg-build-(.*),group=1
+
+      - name: build-push pkg-builder
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
+        with:
+          context: ./anaconda-pkg-build/linux
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./anaconda-pkg-build/linux/Dockerfile
+          platforms: linux/amd64,linux/ppc64le,linux/arm64/v8,linux/s390x
+          build-args: |
+            BASEVERSION=7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') }}
+
+      - name: Docker meta for Concourse
+        id: concourse-meta
+        uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5
+        with:
+          images: |
+            continuumio/anaconda-pkg-build
+            public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+          tags: |
+            type=ref,event=branch,suffix=-amd64
+            type=ref,event=pr,suffix=-amd64
+            type=match,pattern=pkg-build-(.*),group=1,suffix=-amd64
+          flavor: |
+            latest=false
+
+      - name: build-push pkg-builder-concourse
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
+        with:
+          context: ./anaconda-pkg-build/linux
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./anaconda-pkg-build/linux/Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            BASEVERSION=7
+          tags: ${{ steps.concourse-meta.outputs.tags }}
+          labels: ${{ steps.concourse-meta.outputs.labels }}
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/anaconda_pkg_build_linux_cuda.yml
+++ b/.github/workflows/anaconda_pkg_build_linux_cuda.yml
@@ -67,7 +67,7 @@ jobs:
           file: ./anaconda-pkg-build/linux/cuda/Dockerfile
           platforms: linux/amd64
           build-args: |
-            CUDA_VERSION=11.8
+            CUDA_VERSION=11.8.0
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') }}

--- a/anaconda-pkg-build/cuda/linux-64/Dockerfile
+++ b/anaconda-pkg-build/cuda/linux-64/Dockerfile
@@ -1,0 +1,120 @@
+# This container has the CUDA compilers installed for v11.8, and compilers can be provided
+# by conda via a recipe for higher versions.
+# (defaults' cudatoolkit 11.8 package doesn't provide compilers)
+FROM nvidia/cuda:11.8.0-devel-centos7
+
+# this is mostly copied from public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+
+# ulimit needs to be turned down: https://bugzilla.redhat.com/show_bug.cgi?id=1537564
+# hadolint ignore=DL3031,DL3033
+RUN ulimit -n 1024 \
+    && yum install -q -y deltarpm \
+    # Hack to force locale generation, if needed
+    && yum update -q -y glibc-common \
+    && yum install -q -y \
+        #----------------------------------------
+        # X11-related libraries needed for various CDTs
+        #----------------------------------------
+        libX11 \
+        libXau \
+        libxcb \
+        libXcomposite \
+        libXcursor \
+        libXdamage \
+        libXdmcp \
+        libXext \
+        libXfixes \
+        libXi \
+        libXinerama \
+        libXrandr \
+        libXrender \
+        libXScrnSaver \
+        libXt \
+        libXtst \
+        #----------------------------------------
+        # MESA 3D graphics library
+        #----------------------------------------
+        #mesa-libEGL \
+        #mesa-libGL \
+        #mesa-libGLU \
+        #----------------------------------------
+        # Vendor-neutral OpenGL
+        #----------------------------------------
+        libglvnd-opengl \
+        #----------------------------------------
+        # X11 virtual framebuffer; useful for testing GUI apps
+        #----------------------------------------
+        xorg-x11-server-Xvfb \
+        #----------------------------------------
+        # Other hardware and low-level system libraries
+        #----------------------------------------
+        #alsa-lib \
+        #libselinux \
+        #pam \
+        #pciutils-libs \
+        #----------------------------------------
+        # Low-level and basic system utilities.
+        #
+        # NOTE: previous versions of this image included tools like `patch`
+        # and `make`; these days, we prefer package recipes list the
+        # equivalent conda packages as build dependencies, rather than
+        # assume the build container provides these tools.
+        #----------------------------------------
+        curl \
+        file \
+        net-tools \
+        openssh-clients \
+        procps-ng \
+        psmisc \
+        rsync \
+        tar \
+        util-linux \
+        #wget \
+        which \
+    && yum clean all
+
+# Set the locale
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+ARG MC_VER=py39_23.1.0-1
+
+RUN curl -sSL -o /tmp/miniconda.sh \
+        "https://repo.anaconda.com/miniconda/Miniconda3-${MC_VER}-Linux-$(uname -m)".sh \
+    && sha256sum /tmp/miniconda.sh \
+    && /bin/bash /tmp/miniconda.sh -bfp /opt/conda \
+    && rm -fv /tmp/miniconda.sh \
+    # ensure there are no out of range userids
+    && chown -R root:root /opt/conda
+
+# hadolint ignore=DL3059
+RUN MC_ARCH="$(uname -m)" \
+    && if [ "${MC_ARCH}" = "x86_64" ]; then subdir="64"; else subdir="${MC_ARCH}"; fi \
+    && /opt/conda/bin/conda update --all --quiet --yes \
+    && /opt/conda/bin/conda install --quiet --yes conda-build conda-libmamba-solver \
+    && /opt/conda/bin/conda clean --all --yes \
+    && rm -fv /opt/conda/.condarc \
+    && /opt/conda/bin/conda config --system --set show_channel_urls True \
+    && /opt/conda/bin/conda config --system --set add_pip_as_python_dependency False \
+    && /opt/conda/bin/conda config --show-sources \
+    # The solver has to be set right after the `conda clean` call and before the next
+    # `conda install` call to avoid incompatible cache formats.
+    && /opt/conda/bin/conda config --system --set solver libmamba \
+    # Cache our C and C++ compilers so we don't have to download them with
+    # each build; skipping the Fortran compiler as it's not used often
+    # enough to justify the cache space.  Note that we do NOT want to
+    # _actually install_ the compilers in the base environment, as doing so
+    # runs the risk of buggy recipes falling back to those compilers via
+    # `$PATH`, rather than erroring out due to missing compilers in the
+    # `build`/`host` requirements.
+    #
+    # Note, too, that this MUST come _after_ the `conda clean --all` above,
+    # or the compilers will be dumped from the package cache.
+    && /opt/conda/bin/conda install --download-only --quiet --yes \
+        "gcc_linux-$subdir=${GCC_VER}" "gxx_linux-$subdir=${GCC_VER}" \
+    && /opt/conda/bin/conda clean --index-cache --yes
+
+ENV PATH="/opt/conda/bin:${PATH}"
+
+CMD [ "/bin/bash" ]

--- a/anaconda-pkg-build/cuda/linux-64/Dockerfile
+++ b/anaconda-pkg-build/cuda/linux-64/Dockerfile
@@ -1,7 +1,8 @@
-# This container has the CUDA compilers installed for v11.8, and compilers can be provided
-# by conda via a recipe for higher versions.
-# (defaults' cudatoolkit 11.8 package doesn't provide compilers)
-FROM nvidia/cuda:11.8.0-devel-centos7
+# This container has the CUDA compilers installed. For versions less than 12, they're used,
+# because defaults' cudatoolkit <= 11.8 package doesn't provide compilers.
+# But not for versions equal and greater than 12.
+ARG CUDA_VERSION
+FROM nvidia/cuda:${CUDA_VERSION}-devel-centos7
 
 # this is mostly copied from public.ecr.aws/y0o4y9o3/anaconda-pkg-build
 

--- a/anaconda-pkg-build/linux/cuda/Dockerfile
+++ b/anaconda-pkg-build/linux/cuda/Dockerfile
@@ -1,7 +1,7 @@
 # This container has the CUDA compilers installed. For versions less than 12, they're used,
 # because defaults' cudatoolkit <= 11.8 package doesn't provide compilers.
 # But not for versions equal and greater than 12.
-ARG CUDA_VERSION=11.8
+ARG CUDA_VERSION=11.8.0
 FROM nvidia/cuda:${CUDA_VERSION}-devel-centos7
 
 # this is mostly copied from public.ecr.aws/y0o4y9o3/anaconda-pkg-build

--- a/anaconda-pkg-build/linux/cuda/Dockerfile
+++ b/anaconda-pkg-build/linux/cuda/Dockerfile
@@ -7,7 +7,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-centos7
 # this is mostly copied from public.ecr.aws/y0o4y9o3/anaconda-pkg-build
 
 # ulimit needs to be turned down: https://bugzilla.redhat.com/show_bug.cgi?id=1537564
-# hadolint ignore=DL3031,DL3033
+# hadolint ignore=DL3031,DL3033,SC3045
 RUN ulimit -n 1024 \
     && yum install -q -y deltarpm \
     # Hack to force locale generation, if needed

--- a/anaconda-pkg-build/linux/cuda/Dockerfile
+++ b/anaconda-pkg-build/linux/cuda/Dockerfile
@@ -1,7 +1,7 @@
 # This container has the CUDA compilers installed. For versions less than 12, they're used,
 # because defaults' cudatoolkit <= 11.8 package doesn't provide compilers.
 # But not for versions equal and greater than 12.
-ARG CUDA_VERSION
+ARG CUDA_VERSION=11.8
 FROM nvidia/cuda:${CUDA_VERSION}-devel-centos7
 
 # this is mostly copied from public.ecr.aws/y0o4y9o3/anaconda-pkg-build


### PR DESCRIPTION
This is almost the same as the anaconda-pkg-build container, but derived from Nvidia's CentOS 7 CUDA 11.8.0 image.

See comment in the Dockerfile for info on what it contains and what conda must provide.

This is a copy over of [this](https://github.com/anaconda-distribution/distro-incubator/blob/dpetry-ansible-cuda-updates/rmartins/ansible-cuda/docker/Dockerfile) file which has already been used to successfully build CUDA packages.