### PR TITLE
anaconda-pkg-build: Switch to miniconda 23.10.0-1

### DIFF
--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -86,7 +86,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-ARG MC_VER=py39_23.11.0-2
+ARG MC_VER=py39_23.10.0-1
 
 RUN curl -sSL -o /tmp/miniconda.sh \
         "https://repo.anaconda.com/miniconda/Miniconda3-${MC_VER}-Linux-$(uname -m)".sh \

--- a/anaconda-pkg-build/linux/Dockerfile
+++ b/anaconda-pkg-build/linux/Dockerfile
@@ -86,7 +86,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-ARG MC_VER=py39_23.1.0-1
+ARG MC_VER=py39_23.11.0-2
 
 RUN curl -sSL -o /tmp/miniconda.sh \
         "https://repo.anaconda.com/miniconda/Miniconda3-${MC_VER}-Linux-$(uname -m)".sh \
@@ -100,15 +100,12 @@ RUN curl -sSL -o /tmp/miniconda.sh \
 RUN MC_ARCH="$(uname -m)" \
     && if [ "${MC_ARCH}" = "x86_64" ]; then subdir="64"; else subdir="${MC_ARCH}"; fi \
     && /opt/conda/bin/conda update --all --quiet --yes \
-    && /opt/conda/bin/conda install --quiet --yes conda-build conda-libmamba-solver \
+    && /opt/conda/bin/conda install --quiet --yes conda-build \
     && /opt/conda/bin/conda clean --all --yes \
     && rm -fv /opt/conda/.condarc \
     && /opt/conda/bin/conda config --system --set show_channel_urls True \
     && /opt/conda/bin/conda config --system --set add_pip_as_python_dependency False \
     && /opt/conda/bin/conda config --show-sources \
-    # The solver has to be set right after the `conda clean` call and before the next
-    # `conda install` call to avoid incompatible cache formats.
-    && /opt/conda/bin/conda config --system --set solver libmamba \
     # Cache our C and C++ compilers so we don't have to download them with
     # each build; skipping the Fortran compiler as it's not used often
     # enough to justify the cache space.  Note that we do NOT want to

--- a/anaconda-pkg-build/linux/cuda/Dockerfile
+++ b/anaconda-pkg-build/linux/cuda/Dockerfile
@@ -79,7 +79,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-ARG MC_VER=py39_23.1.0-1
+ARG MC_VER=py39_23.10.0-1
 
 RUN curl -sSL -o /tmp/miniconda.sh \
         "https://repo.anaconda.com/miniconda/Miniconda3-${MC_VER}-Linux-$(uname -m)".sh \
@@ -93,15 +93,12 @@ RUN curl -sSL -o /tmp/miniconda.sh \
 RUN MC_ARCH="$(uname -m)" \
     && if [ "${MC_ARCH}" = "x86_64" ]; then subdir="64"; else subdir="${MC_ARCH}"; fi \
     && /opt/conda/bin/conda update --all --quiet --yes \
-    && /opt/conda/bin/conda install --quiet --yes conda-build conda-libmamba-solver \
+    && /opt/conda/bin/conda install --quiet --yes conda-build \
     && /opt/conda/bin/conda clean --all --yes \
     && rm -fv /opt/conda/.condarc \
     && /opt/conda/bin/conda config --system --set show_channel_urls True \
     && /opt/conda/bin/conda config --system --set add_pip_as_python_dependency False \
     && /opt/conda/bin/conda config --show-sources \
-    # The solver has to be set right after the `conda clean` call and before the next
-    # `conda install` call to avoid incompatible cache formats.
-    && /opt/conda/bin/conda config --system --set solver libmamba \
     # Cache our C and C++ compilers so we don't have to download them with
     # each build; skipping the Fortran compiler as it's not used often
     # enough to justify the cache space.  Note that we do NOT want to


### PR DESCRIPTION
This also removes the manual libmamba steps as libmambda became default with conda 23.10.0.