### PR TITLE
Use group name in PR titles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,13 @@
     {
       "matchDatasources": ["custom.anaconda"],
       "groupName": "Anaconda Distribution",
+      "commitMessageTopic": "{{{groupName}}}",
       "separateMajorMinor": false
     },
     {
       "matchDatasources": ["custom.miniconda"],
       "groupName": "Miniconda",
+      "commitMessageTopic": "{{{groupName}}}",
       "separateMajorMinor": false
     }
   ],


### PR DESCRIPTION
The PR titles from renovate contain `custom.miniconda`. `commitMessageTopic` should change this to the group name instead.