### PR TITLE
Explicltly set commitMessageTopic in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,13 +7,13 @@
     {
       "matchDatasources": ["custom.anaconda"],
       "groupName": "Anaconda Distribution",
-      "commitMessageTopic": "{{{groupName}}}",
+      "commitMessageTopic": "Anaconda Distribution",
       "separateMajorMinor": false
     },
     {
       "matchDatasources": ["custom.miniconda"],
       "groupName": "Miniconda",
-      "commitMessageTopic": "{{{groupName}}}",
+      "commitMessageTopic": "Miniconda",
       "separateMajorMinor": false
     }
   ],


### PR DESCRIPTION
It appears that `groupName` is not being rendered in `commitMessageTopic`, so set the values explicitly.