### PR TITLE
Disable dependabot in favour of renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
This avoids duplicated PRs and renovate anyways handles more updates than dependabot.