### PR TITLE
Change Debian tags from bullseye-slim to 11.9-slim to be renovate managed

### DIFF
--- a/anaconda3/debian/Dockerfile
+++ b/anaconda3/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:11.9-slim
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH

--- a/miniconda3/debian/Dockerfile
+++ b/miniconda3/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:11.9-slim
 
 LABEL maintainer="Anaconda, Inc"
 


### PR DESCRIPTION
bullseye = Debian 11
bookworm = Debian 12

Renovate does not propose upgrades from bullseye to bookworm as it cannot know what is newer. With the switch to 11.9-slim it should be able to propose the update to 12.5-slim.